### PR TITLE
Add blob-convergence shader entry and improve blob physics

### DIFF
--- a/packages/ui/src/lib/components/PostControlBar.svelte
+++ b/packages/ui/src/lib/components/PostControlBar.svelte
@@ -115,7 +115,7 @@
 			<div class="flex self-center h-full content-center">
 				<a
 					href={downloadLink}
-					download={`${postId}.webm`}
+					download={`${postId}.${typeof MediaRecorder !== 'undefined' && MediaRecorder.isTypeSupported('video/mp4') ? 'mp4' : 'webm'}`}
 					class="flex items-center text-neutral-600 text-sm"
 				>
 					<span class="flex items-center bg-emerald-50/40 px-4 py-1 rounded-full"

--- a/packages/ui/src/lib/components/content-params/ParamInput.svelte
+++ b/packages/ui/src/lib/components/content-params/ParamInput.svelte
@@ -37,6 +37,7 @@
 				label={param.name}
 				name={inputId}
 			/>
+			<span class="text-xs text-neutral-500">{param.value}</span>
 		{:else}
 			<Input
 				wrapperClass="w-full"

--- a/packages/ui/src/lib/entries/blob-convergence.ts
+++ b/packages/ui/src/lib/entries/blob-convergence.ts
@@ -1,0 +1,631 @@
+import { type Post, PostType, type RendererParams } from '@sc/model';
+import { BookOfShadersContent } from '../book-of-shaders';
+import { type IUniform } from '$lib/three';
+import { DataTexture, FloatType, NearestFilter, RGBAFormat, Vector2 } from 'three';
+import { type ContentParams, numberParam, selectParam, paramsById } from '$lib/content-params';
+
+/* ── constants ─────────────────────────────────────────────── */
+
+const MAX_BLOBS = 100;
+const SUBSTEPS = 6;
+const MAX_DISPLACEMENT = 8;
+const MERGE_OVERLAP = 0.7;
+const COLOR_LERP_SPEED = 0.025;
+
+/* ── types ─────────────────────────────────────────────────── */
+
+interface VPoint {
+	x: number;
+	y: number;
+	px: number;
+	py: number;
+}
+
+interface SoftBlob {
+	cx: number;
+	cy: number;
+	ring: VPoint[];
+	restLens: number[];
+	bendLens: number[];
+	restArea: number;
+	avgRadius: number;
+	maxDX: number;
+	maxDY: number;
+	baseColor: [number, number, number];
+	renderColor: [number, number, number];
+}
+
+/* ── palette ───────────────────────────────────────────────── */
+
+const palette: [number, number, number][] = [
+	[66, 165, 245],
+	[210, 175, 140],
+	[230, 110, 95],
+	[200, 40, 100],
+	[235, 210, 55],
+	[148, 128, 200],
+	[80, 75, 68],
+	[45, 100, 220],
+	[155, 168, 28],
+	[160, 118, 78],
+	[210, 170, 200],
+	[115, 188, 198],
+	[100, 58, 28],
+	[0, 210, 155],
+	[200, 28, 28],
+	[180, 80, 180],
+	[90, 200, 90],
+	[255, 160, 60],
+	[60, 60, 160],
+	[200, 200, 80],
+	[140, 80, 60],
+	[80, 180, 220],
+	[220, 120, 180],
+	[120, 160, 80],
+	[180, 140, 200],
+	[100, 200, 180],
+	[200, 80, 60],
+	[60, 140, 120],
+	[220, 180, 120],
+	[140, 100, 180]
+];
+
+/* ── physics helpers ───────────────────────────────────────── */
+
+const WALL = 3;
+
+function polyArea(ring: VPoint[]): number {
+	let a = 0;
+	const n = ring.length;
+	for (let i = 0; i < n; i++) {
+		const j = (i + 1) % n;
+		a += ring[i].x * ring[j].y - ring[j].x * ring[i].y;
+	}
+	return Math.abs(a) / 2;
+}
+
+/* ── params ─────────────────────────────────────────────────── */
+
+const defaultParams: ContentParams = [
+	numberParam('Blobs', 33, { min: 1, max: 100, step: 1 }),
+	numberParam('Speed', 2.7, { min: 0.05, max: 5, step: 0.05 }),
+	numberParam('Spring K', 0.106, { min: 0.001, max: 0.5, step: 0.001 }),
+	numberParam('Pressure', 2920, { min: 10, max: 5000, step: 10 }),
+	numberParam('Damping', 0.979, { min: 0.95, max: 1, step: 0.001 }),
+	numberParam('Ring Nodes', 17, { min: 12, max: 48, step: 1 }),
+	numberParam('Color Bleed', 1.4, { min: 1, max: 5, step: 0.1 }),
+	selectParam('Show Mesh', ['Off', 'On'], 'Off')
+];
+
+/* ── content class ─────────────────────────────────────────── */
+
+class BlobConvergenceContent extends BookOfShadersContent {
+	private blobs: SoftBlob[] = [];
+	private merges = new Map<string, { hostIdx: number }>();
+
+	private blobData: Float32Array;
+	private blobTexture: DataTexture;
+
+	private physW = 1080;
+	private physH = 1920;
+	private numBlobs = 33;
+	private speed = 2.7;
+	private springK = 0.106;
+	private pressureK = 2920;
+	private damping = 0.979;
+	private numRing = 17;
+
+	private params: ContentParams = defaultParams.map((p) => ({ ...p }));
+
+	constructor() {
+		super();
+
+		this.blobData = new Float32Array(MAX_BLOBS * 2 * 4);
+		this.blobTexture = new DataTexture(this.blobData, MAX_BLOBS, 2, RGBAFormat, FloatType);
+		this.blobTexture.minFilter = NearestFilter;
+		this.blobTexture.magFilter = NearestFilter;
+
+		this.uniforms.u_blobData = { value: this.blobTexture } as IUniform;
+		this.uniforms.u_numBlobs = { value: 0 } as IUniform;
+		this.uniforms.u_physSize = { value: new Vector2(1080, 1920) } as IUniform;
+		this.uniforms.u_showMesh = { value: 0.0 } as IUniform;
+		this.uniforms.u_colorBleed = { value: 2.2 } as IUniform;
+	}
+
+	/* ── blob creation ─────────────────────────────────────── */
+
+	private initBlobs() {
+		this.blobs = [];
+		this.merges.clear();
+		const N = this.numRing;
+		const W = this.physW,
+			H = this.physH;
+		const cols = Math.ceil(Math.sqrt(this.numBlobs * (W / H)));
+		const rows = Math.ceil(this.numBlobs / cols);
+		const baseR = Math.min(W / (cols * 2.5), H / (rows * 2.5), 130);
+
+		for (let idx = 0; idx < this.numBlobs; idx++) {
+			const col = idx % cols;
+			const row = Math.floor(idx / cols);
+			const cx = (col + 0.5) * (W / cols) + (Math.random() - 0.5) * 40;
+			const cy = (row + 0.5) * (H / rows) + (Math.random() - 0.5) * 40;
+			const rot = Math.random() * Math.PI * 2;
+			const ang = Math.random() * Math.PI * 2;
+			const iv = this.speed;
+
+			const sv = 0.8 + Math.random() * 0.4;
+			const av = 0.85 + Math.random() * 0.3;
+			const rx = baseR * sv * av;
+			const ry = (baseR * sv) / av;
+
+			const ring: VPoint[] = [];
+			for (let i = 0; i < N; i++) {
+				const a = (i / N) * Math.PI * 2 + rot;
+				const c = Math.cos(a - rot),
+					s = Math.sin(a - rot);
+				const r = (rx * ry) / Math.sqrt((ry * c) ** 2 + (rx * s) ** 2);
+				const x = cx + Math.cos(a) * r;
+				const y = cy + Math.sin(a) * r;
+				ring.push({ x, y, px: x - Math.cos(ang) * iv, py: y - Math.sin(ang) * iv });
+			}
+
+			const restLens: number[] = [];
+			for (let i = 0; i < N; i++) {
+				const j = (i + 1) % N;
+				restLens.push(Math.sqrt((ring[j].x - ring[i].x) ** 2 + (ring[j].y - ring[i].y) ** 2));
+			}
+			const bendLens: number[] = [];
+			for (let i = 0; i < N; i++) {
+				const j = (i + 2) % N;
+				bendLens.push(Math.sqrt((ring[j].x - ring[i].x) ** 2 + (ring[j].y - ring[i].y) ** 2));
+			}
+
+			const color: [number, number, number] = [...palette[idx % palette.length]];
+			this.blobs.push({
+				cx,
+				cy,
+				ring,
+				restLens,
+				bendLens,
+				restArea: polyArea(ring),
+				avgRadius: (rx + ry) / 2,
+				maxDX: rx,
+				maxDY: ry,
+				baseColor: color,
+				renderColor: [...color]
+			});
+		}
+	}
+
+	/* ── physics step ──────────────────────────────────────── */
+
+	private stepBlob(blob: SoftBlob) {
+		const N = blob.ring.length;
+		const dt = 1 / SUBSTEPS;
+
+		for (let step = 0; step < SUBSTEPS; step++) {
+			for (const p of blob.ring) {
+				let dx = (p.x - p.px) * this.damping;
+				let dy = (p.y - p.py) * this.damping;
+				const spd = Math.sqrt(dx * dx + dy * dy);
+				if (spd > MAX_DISPLACEMENT * dt) {
+					const s = (MAX_DISPLACEMENT * dt) / spd;
+					dx *= s;
+					dy *= s;
+				}
+				p.px = p.x;
+				p.py = p.y;
+				p.x += dx;
+				p.y += dy;
+			}
+
+			const area = polyArea(blob.ring);
+			const P = (this.pressureK * dt * dt) / Math.max(area, 1);
+			for (let i = 0; i < N; i++) {
+				const j = (i + 1) % N;
+				const pi = blob.ring[i],
+					pj = blob.ring[j];
+				const ex = pj.x - pi.x,
+					ey = pj.y - pi.y;
+				const el = Math.sqrt(ex * ex + ey * ey) || 0.001;
+				const f = P * el * 0.5;
+				const nx = ey / el,
+					ny = -ex / el;
+				pi.x += nx * f;
+				pi.y += ny * f;
+				pj.x += nx * f;
+				pj.y += ny * f;
+			}
+
+			const kE = this.springK * dt;
+			for (let i = 0; i < N; i++) {
+				const j = (i + 1) % N;
+				const pi = blob.ring[i],
+					pj = blob.ring[j];
+				const dx = pj.x - pi.x,
+					dy = pj.y - pi.y;
+				const d = Math.sqrt(dx * dx + dy * dy) || 0.001;
+				const diff = (d - blob.restLens[i]) / d;
+				const fx = dx * diff * kE * 0.5,
+					fy = dy * diff * kE * 0.5;
+				pi.x += fx;
+				pi.y += fy;
+				pj.x -= fx;
+				pj.y -= fy;
+			}
+
+			const kB = this.springK * 0.4 * dt;
+			for (let i = 0; i < N; i++) {
+				const j = (i + 2) % N;
+				const pi = blob.ring[i],
+					pj = blob.ring[j];
+				const dx = pj.x - pi.x,
+					dy = pj.y - pi.y;
+				const d = Math.sqrt(dx * dx + dy * dy) || 0.001;
+				const diff = (d - blob.bendLens[i]) / d;
+				const fx = dx * diff * kB * 0.5,
+					fy = dy * diff * kB * 0.5;
+				pi.x += fx;
+				pi.y += fy;
+				pj.x -= fx;
+				pj.y -= fy;
+			}
+
+			const WR = this.physW - WALL,
+				HB = this.physH - WALL;
+			for (const p of blob.ring) {
+				if (p.x < WALL) {
+					p.x = WALL;
+					if (p.px < WALL) p.px = WALL;
+				}
+				if (p.x > WR) {
+					p.x = WR;
+					if (p.px > WR) p.px = WR;
+				}
+				if (p.y < WALL) {
+					p.y = WALL;
+					if (p.py < WALL) p.py = WALL;
+				}
+				if (p.y > HB) {
+					p.y = HB;
+					if (p.py > HB) p.py = HB;
+				}
+			}
+		}
+
+		// Maintain speed
+		let vx = 0,
+			vy = 0;
+		for (const p of blob.ring) {
+			vx += p.x - p.px;
+			vy += p.y - p.py;
+		}
+		vx /= N;
+		vy /= N;
+		const cs = Math.sqrt(vx * vx + vy * vy);
+		if (cs > 0.0001) {
+			const dv = (this.speed / cs - 1) * 0.03;
+			for (const p of blob.ring) {
+				p.px -= vx * dv;
+				p.py -= vy * dv;
+			}
+		} else {
+			const a = Math.random() * Math.PI * 2;
+			for (const p of blob.ring) {
+				p.px -= Math.cos(a) * this.speed * 0.5;
+				p.py -= Math.sin(a) * this.speed * 0.5;
+			}
+		}
+
+		// Centroid + extents
+		blob.cx = 0;
+		blob.cy = 0;
+		for (const p of blob.ring) {
+			blob.cx += p.x;
+			blob.cy += p.y;
+		}
+		blob.cx /= N;
+		blob.cy /= N;
+		blob.maxDX = 0;
+		blob.maxDY = 0;
+		for (const p of blob.ring) {
+			blob.maxDX = Math.max(blob.maxDX, Math.abs(p.x - blob.cx));
+			blob.maxDY = Math.max(blob.maxDY, Math.abs(p.y - blob.cy));
+		}
+	}
+
+	private collideBlobs() {
+		for (let i = 0; i < this.blobs.length; i++) {
+			for (let j = i + 1; j < this.blobs.length; j++) {
+				const a = this.blobs[i],
+					b = this.blobs[j];
+				const dx = b.cx - a.cx,
+					dy = b.cy - a.cy;
+				const dist = Math.sqrt(dx * dx + dy * dy) || 0.001;
+				const minD = a.avgRadius + b.avgRadius;
+				if (dist >= minD) continue;
+				const nx = dx / dist,
+					ny = dy / dist;
+				const push = (minD - dist) * 0.08;
+				for (const p of a.ring) {
+					p.x -= nx * push;
+					p.y -= ny * push;
+				}
+				for (const p of b.ring) {
+					p.x += nx * push;
+					p.y += ny * push;
+				}
+			}
+		}
+	}
+
+	/* ── merge logic ───────────────────────────────────────── */
+
+	private updateMerges() {
+		const active = new Set<string>();
+		const merged = new Set<number>();
+
+		for (let i = 0; i < this.blobs.length; i++) {
+			for (let j = i + 1; j < this.blobs.length; j++) {
+				const a = this.blobs[i],
+					b = this.blobs[j];
+				const dx = b.cx - a.cx,
+					dy = b.cy - a.cy;
+				const dist = Math.sqrt(dx * dx + dy * dy);
+				if (dist < (a.avgRadius + b.avgRadius) * MERGE_OVERLAP) {
+					const key = `${i},${j}`;
+					active.add(key);
+					if (!this.merges.has(key)) {
+						this.merges.set(key, { hostIdx: Math.random() < 0.5 ? i : j });
+					}
+					const m = this.merges.get(key)!;
+					const guestIdx = m.hostIdx === i ? j : i;
+					const hostColor = this.blobs[m.hostIdx].baseColor;
+					const guest = this.blobs[guestIdx];
+					merged.add(guestIdx);
+					for (let c = 0; c < 3; c++) {
+						guest.renderColor[c] += (hostColor[c] - guest.renderColor[c]) * COLOR_LERP_SPEED;
+					}
+				}
+			}
+		}
+
+		for (const k of this.merges.keys()) {
+			if (!active.has(k)) this.merges.delete(k);
+		}
+
+		for (let i = 0; i < this.blobs.length; i++) {
+			if (!merged.has(i)) {
+				const bl = this.blobs[i];
+				for (let c = 0; c < 3; c++) {
+					bl.renderColor[c] += (bl.baseColor[c] - bl.renderColor[c]) * COLOR_LERP_SPEED;
+				}
+			}
+		}
+	}
+
+	/* ── texture upload ────────────────────────────────────── */
+
+	private syncTexture() {
+		for (let i = 0; i < this.blobs.length; i++) {
+			const b = this.blobs[i];
+			const p = i * 4; // row 0
+			this.blobData[p] = b.cx;
+			this.blobData[p + 1] = b.cy;
+			this.blobData[p + 2] = b.maxDX;
+			this.blobData[p + 3] = b.maxDY;
+
+			const c = MAX_BLOBS * 4 + i * 4; // row 1
+			this.blobData[c] = b.renderColor[0] / 255;
+			this.blobData[c + 1] = b.renderColor[1] / 255;
+			this.blobData[c + 2] = b.renderColor[2] / 255;
+			this.blobData[c + 3] = 1;
+		}
+		// Zero out unused slots
+		for (let i = this.blobs.length; i < MAX_BLOBS; i++) {
+			const p = i * 4;
+			this.blobData[p] = -9999;
+			this.blobData[p + 3] = 0;
+			const c = MAX_BLOBS * 4 + i * 4;
+			this.blobData[c + 3] = 0;
+		}
+		this.blobTexture.needsUpdate = true;
+		this.uniforms.u_numBlobs.value = this.blobs.length;
+	}
+
+	/* ── lifecycle ─────────────────────────────────────────── */
+
+	start = (params: RendererParams) => {
+		const { container } = params;
+		container.style.aspectRatio = '9 / 16';
+		container.style.maxHeight = '90vh';
+		container.style.margin = '0 auto';
+		container.style.width = 'auto';
+
+		super.start(params);
+
+		// Physics runs at fixed resolution, shader maps via UV (DPR-independent)
+		this.physW = 1080;
+		this.physH = 1920;
+		this.uniforms.u_physSize.value.set(this.physW, this.physH);
+		this.initBlobs();
+	};
+
+	onRender = () => {
+		for (const b of this.blobs) this.stepBlob(b);
+		this.collideBlobs();
+
+		// Final wall clamp after all forces (collision push + speed maintenance can escape)
+		const WR = this.physW - WALL,
+			HB = this.physH - WALL;
+		for (const b of this.blobs) {
+			const N = b.ring.length;
+			for (const p of b.ring) {
+				if (p.x < WALL) {
+					p.x = WALL;
+					if (p.px < WALL) p.px = WALL;
+				}
+				if (p.x > WR) {
+					p.x = WR;
+					if (p.px > WR) p.px = WR;
+				}
+				if (p.y < WALL) {
+					p.y = WALL;
+					if (p.py < WALL) p.py = WALL;
+				}
+				if (p.y > HB) {
+					p.y = HB;
+					if (p.py > HB) p.py = HB;
+				}
+			}
+			// Recompute centroid + extents after final clamp
+			b.cx = 0;
+			b.cy = 0;
+			for (const p of b.ring) {
+				b.cx += p.x;
+				b.cy += p.y;
+			}
+			b.cx /= N;
+			b.cy /= N;
+			b.maxDX = 0;
+			b.maxDY = 0;
+			for (const p of b.ring) {
+				b.maxDX = Math.max(b.maxDX, Math.abs(p.x - b.cx));
+				b.maxDY = Math.max(b.maxDY, Math.abs(p.y - b.cy));
+			}
+		}
+
+		this.updateMerges();
+		this.syncTexture();
+		super.onRender();
+	};
+
+	stop = () => {
+		super.stop();
+		this.blobTexture.dispose();
+	};
+
+	getParams = (): ContentParams => this.params;
+
+	setParams = (p: ContentParams) => {
+		this.params = p;
+		const byId = paramsById(p);
+		const val = (id: string) => byId[id]?.value as number;
+
+		const newCount = val('blobs');
+		const newRing = val('ring-nodes');
+		const needsRebuild = newCount !== this.numBlobs || newRing !== this.numRing;
+
+		this.speed = val('speed');
+		this.springK = val('spring-k');
+		this.pressureK = val('pressure');
+		this.damping = val('damping');
+		this.numBlobs = newCount;
+		this.numRing = newRing;
+		this.uniforms.u_showMesh.value = byId['show-mesh']?.value === 'On' ? 1.0 : 0.0;
+		this.uniforms.u_colorBleed.value = val('color-bleed') || 2.2;
+
+		if (needsRebuild) this.initBlobs();
+	};
+
+	/* ── shaders ────────────────────────────────────────────── */
+
+	protected getVertexShader = () => `
+		varying vec2 vUv;
+		void main() {
+			gl_Position = vec4(position, 1.0);
+			vUv = position.xy * 0.5 + 0.5;
+		}
+	`;
+
+	getFragmentShader = () => `
+		#ifdef GL_ES
+		precision highp float;
+		#endif
+
+		varying vec2 vUv;
+		uniform float u_time;
+		uniform sampler2D u_blobData;
+		uniform int u_numBlobs;
+		uniform vec2 u_physSize;
+		uniform float u_showMesh;
+		uniform float u_colorBleed;
+
+
+		void main() {
+			// vUv is 0..1 across the quad — completely DPR-independent
+			// Map to physics space with Y flipped (vUv.y=0 is bottom, physics y=0 is top)
+			vec2 st = vec2(vUv.x * u_physSize.x, (1.0 - vUv.y) * u_physSize.y);
+
+			vec3 bgColor = vec3(0.965, 0.945, 0.922);
+
+			float totalField = 0.0;
+			vec3 weightedColor = vec3(0.0);
+
+			for (int i = 0; i < ${MAX_BLOBS}; i++) {
+				if (i >= u_numBlobs) break;
+
+				float u = (float(i) + 0.5) / ${MAX_BLOBS}.0;
+				vec4 posData = texture2D(u_blobData, vec2(u, 0.25));
+				vec4 colData = texture2D(u_blobData, vec2(u, 0.75));
+
+				vec2 blobPos = posData.xy;
+				vec2 radii = posData.zw * u_colorBleed;
+
+				if (radii.x < 1.0 || radii.y < 1.0) continue;
+
+				vec2 diff = st - blobPos;
+				vec2 norm = diff / radii;
+				float dist2 = dot(norm, norm);
+
+				float field = exp(-dist2 * 2.8);
+
+				totalField += field;
+				weightedColor += colData.rgb * field;
+			}
+
+			vec3 blobColor = weightedColor / max(totalField, 0.001);
+
+			float alpha = smoothstep(0.08, 0.55, totalField);
+
+			vec3 color = mix(bgColor, blobColor, alpha);
+
+			// Mesh overlay: show centroid dots and physics radius outlines
+			if (u_showMesh > 0.5) {
+				for (int i = 0; i < ${MAX_BLOBS}; i++) {
+					if (i >= u_numBlobs) break;
+					float u = (float(i) + 0.5) / ${MAX_BLOBS}.0;
+					vec4 pd = texture2D(u_blobData, vec2(u, 0.25));
+					vec2 bp = pd.xy;
+					vec2 rd = pd.zw;
+					float d = length(st - bp);
+					// Centroid dot
+					if (d < 5.0) color = vec3(1.0, 0.3, 0.0);
+					// Physics radius outline
+					vec2 nr = (st - bp) / max(rd, vec2(1.0));
+					float er = length(nr);
+					if (abs(er - 1.0) < 0.03) color = mix(color, vec3(1.0, 0.3, 0.0), 0.6);
+				}
+			}
+
+			gl_FragColor = vec4(color, 1.0);
+		}
+	`;
+}
+
+/* ── post export ───────────────────────────────────────────── */
+
+const post: Post = {
+	summary: {
+		id: 'blob-convergence',
+		tags: ['animation', 'webgl', 'soft-body'],
+		title: 'Blob Convergence',
+		timestamp: new Date(2026, 3, 5),
+		type: PostType.experiment3d,
+		isHidden: false
+	},
+	content: () => new BlobConvergenceContent(),
+	params: defaultParams
+};
+
+export default post;

--- a/packages/ui/src/lib/entries/blob-grid.ts
+++ b/packages/ui/src/lib/entries/blob-grid.ts
@@ -6,7 +6,7 @@ const post: Post = {
 		id: 'blob-grid',
 		tags: ['animation', 'canvas'],
 		title: 'Blob Grid',
-		timestamp: new Date(2024, 11, 4),
+		timestamp: new Date(2026, 3, 4),
 		type: PostType.exploration,
 		isHidden: false
 	},

--- a/packages/ui/src/lib/entries/index.ts
+++ b/packages/ui/src/lib/entries/index.ts
@@ -1,5 +1,6 @@
 /** This file was generated automatically by a script. Do not modify this file manually. */
 import antFarm from "$lib/entries/ant-farm";
+import blobConvergence from "$lib/entries/blob-convergence";
 import blobGrid from "$lib/entries/blob-grid";
 import cell from "$lib/entries/cell";
 import chrysanthemum from "$lib/entries/chrysanthemum";
@@ -24,6 +25,7 @@ import squiggles from "$lib/entries/squiggles";
 
 const posts = {
     [antFarm.summary.id]: antFarm,
+    [blobConvergence.summary.id]: blobConvergence,
     [blobGrid.summary.id]: blobGrid,
     [cell.summary.id]: cell,
     [chrysanthemum.summary.id]: chrysanthemum,

--- a/packages/ui/src/lib/explorations/blob-grid.svelte
+++ b/packages/ui/src/lib/explorations/blob-grid.svelte
@@ -6,468 +6,27 @@
 	const WIDTH = 1080;
 	const HEIGHT = 1920;
 	const BG_COLOR = '#f5f0ea';
-	let numRing = 16;
-	let connections = 1;
 	const WALL_MARGIN = 3;
-	let blobSize = 275;
 
-	let speed = 2.5;
-	let stiffness = 0.012;
-	let pressure = 0.004;
-	let damping = 0.96;
-	let showMesh = true;
-	let topology: 'spokes' | 'rings' | 'cross' | 'grid' = 'grid';
+	const SUBSTEPS = 6;
+	const MAX_DISPLACEMENT = 8;
+
+	let speed = 1.7;
+	let springK = 0.02;
+	let pressureK = 300;
+	let damping = 0.986;
+	let numRing = 28;
+	let numBlobs = 30;
+	let showMesh = false;
 	let panelOpen = false;
 
-	interface Point {
-		ox: number; oy: number;
-		vx: number; vy: number;
-	}
-
-	interface Spring {
-		a: number; b: number;
-		restLen: number; k: number;
-	}
-
-	interface SoftBlob {
-		cx: number; cy: number;
-		vx: number; vy: number;
-		speed: number;
-		points: Point[];
-		springs: Spring[];
-		boundaryN: number; // first boundaryN points are the outer ring
-		restArea: number;
-		color: [number, number, number];
-		phase: number;
-		innerWeights: number[][]; // per interior node: weights over each outer ring node
-	}
-
-	function pdist(pts: Point[], a: number, b: number): number {
-		return Math.sqrt((pts[b].ox - pts[a].ox) ** 2 + (pts[b].oy - pts[a].oy) ** 2);
-	}
-
-	function computeArea(pts: Point[], n: number): number {
-		let area = 0;
-		for (let i = 0; i < n; i++) {
-			const j = (i + 1) % n;
-			area += pts[i].ox * pts[j].oy - pts[j].ox * pts[i].oy;
-		}
-		return Math.abs(area) / 2;
-	}
-
-	function createBlob(topo: typeof topology): SoftBlob {
-		const points: Point[] = [];
-		const springs: Spring[] = [];
-		const N = numRing;
-		const rx = blobSize * 1.09, ry = blobSize * 0.91;
-		const rot = Math.random() * Math.PI * 2;
-
-		// Outer ring is always the first N points — consistent across all topologies
-		for (let i = 0; i < N; i++) {
-			const angle = (i / N) * Math.PI * 2 + rot;
-			points.push({ ox: Math.cos(angle) * rx, oy: Math.sin(angle) * ry, vx: 0, vy: 0 });
-		}
-
-		// Ring neighbor springs (always present)
-		for (let i = 0; i < N; i++) {
-			springs.push({ a: i, b: (i + 1) % N, restLen: pdist(points, i, (i + 1) % N), k: 0.2 });
-		}
-
-		// Cross-connections based on connections param
-		const maxSkip = Math.min(connections, Math.floor(N / 2));
-		for (let skip = 2; skip <= maxSkip; skip++) {
-			for (let i = 0; i < N; i++) {
-				const j = (i + skip) % N;
-				if (j > i) {
-					springs.push({ a: i, b: j, restLen: pdist(points, i, j), k: 0.15 / skip });
-				}
-			}
-		}
-
-		if (topo === 'spokes') {
-			const cIdx = points.length;
-			points.push({ ox: 0, oy: 0, vx: 0, vy: 0 });
-			for (let i = 0; i < N; i++) {
-				springs.push({ a: i, b: cIdx, restLen: pdist(points, i, cIdx), k: 0.15 });
-			}
-
-		} else if (topo === 'rings') {
-			const MN = Math.max(4, Math.round(N / 2)), IN = Math.max(2, Math.round(N / 4));
-			const mStart = points.length;
-			for (let i = 0; i < MN; i++) {
-				const angle = (i / MN) * Math.PI * 2 + rot;
-				points.push({ ox: Math.cos(angle) * rx * 0.6, oy: Math.sin(angle) * ry * 0.6, vx: 0, vy: 0 });
-			}
-			for (let i = 0; i < MN; i++) {
-				springs.push({ a: mStart + i, b: mStart + (i + 1) % MN, restLen: pdist(points, mStart + i, mStart + (i + 1) % MN), k: 0.15 });
-			}
-
-			const iStart = points.length;
-			for (let i = 0; i < IN; i++) {
-				const angle = (i / IN) * Math.PI * 2 + rot;
-				points.push({ ox: Math.cos(angle) * rx * 0.3, oy: Math.sin(angle) * ry * 0.3, vx: 0, vy: 0 });
-			}
-			for (let i = 0; i < IN; i++) {
-				springs.push({ a: iStart + i, b: iStart + (i + 1) % IN, restLen: pdist(points, iStart + i, iStart + (i + 1) % IN), k: 0.1 });
-			}
-
-			const cIdx = points.length;
-			points.push({ ox: 0, oy: 0, vx: 0, vy: 0 });
-
-			for (let i = 0; i < N; i++) {
-				const mi = Math.round((i / N) * MN) % MN;
-				springs.push({ a: i, b: mStart + mi, restLen: pdist(points, i, mStart + mi), k: 0.15 });
-			}
-			for (let i = 0; i < MN; i++) {
-				const ii = Math.round((i / MN) * IN) % IN;
-				springs.push({ a: mStart + i, b: iStart + ii, restLen: pdist(points, mStart + i, iStart + ii), k: 0.12 });
-			}
-			for (let i = 0; i < IN; i++) {
-				springs.push({ a: iStart + i, b: cIdx, restLen: pdist(points, iStart + i, cIdx), k: 0.1 });
-			}
-
-		} else if (topo === 'cross') {
-			for (let i = 0; i < N / 2; i++) {
-				springs.push({ a: i, b: i + N / 2, restLen: pdist(points, i, i + N / 2), k: 0.15 });
-			}
-			for (let i = 0; i < N; i++) {
-				const j = (i + Math.round(N / 4)) % N;
-				springs.push({ a: i, b: j, restLen: pdist(points, i, j), k: 0.1 });
-			}
-
-		} else if (topo === 'grid') {
-			const spacing = Math.max(25, Math.PI * (rx + ry) / N * 0.85);
-			const gMap = new Map<string, number>();
-
-			for (let gy = -(ry - spacing * 0.5); gy <= ry - spacing * 0.5; gy += spacing) {
-				for (let gx = -(rx - spacing * 0.5); gx <= rx - spacing * 0.5; gx += spacing) {
-					if ((gx / rx) ** 2 + (gy / ry) ** 2 < 0.75) {
-						const key = `${Math.round(gx / spacing)},${Math.round(gy / spacing)}`;
-						gMap.set(key, points.length);
-						points.push({ ox: gx, oy: gy, vx: 0, vy: 0 });
-					}
-				}
-			}
-
-			for (const [key, idx] of gMap) {
-				const [kx, ky] = key.split(',').map(Number);
-				for (const [dx, dy] of [[1, 0], [0, 1], [1, 1], [-1, 1]] as [number, number][]) {
-					const nkey = `${kx + dx},${ky + dy}`;
-					if (gMap.has(nkey)) {
-						const restLen = spacing * Math.sqrt(dx ** 2 + dy ** 2);
-						springs.push({ a: idx, b: gMap.get(nkey)!, restLen, k: dx === 0 || dy === 0 ? 0.12 : 0.07 });
-					}
-				}
-			}
-
-			for (const [, gi] of gMap) {
-				const gp = points[gi];
-				let nearest = 0, nearestD = Infinity;
-				for (let ri = 0; ri < N; ri++) {
-					const d = Math.sqrt((points[ri].ox - gp.ox) ** 2 + (points[ri].oy - gp.oy) ** 2);
-					if (d < nearestD) { nearestD = d; nearest = ri; }
-				}
-				springs.push({ a: gi, b: nearest, restLen: nearestD, k: 0.1 });
-			}
-		}
-
-		// Precompute influence weights: for each interior node, how much each ring node pulls it
-		const innerWeights: number[][] = [];
-		for (let i = N; i < points.length; i++) {
-			const p = points[i];
-			const ws = new Array(N);
-			let total = 0;
-			for (let j = 0; j < N; j++) {
-				const rp = points[j];
-				const dx = rp.ox - p.ox, dy = rp.oy - p.oy;
-				ws[j] = 1 / Math.max(dx * dx + dy * dy, 1);
-				total += ws[j];
-			}
-			for (let j = 0; j < N; j++) ws[j] /= total;
-			innerWeights.push(ws);
-		}
-
-		const moveAngle = Math.random() * Math.PI * 2;
-		const baseSpeed = speed + Math.random() * 0.15;
-
-		return {
-			cx: WIDTH / 2, cy: HEIGHT / 2,
-			vx: Math.cos(moveAngle) * baseSpeed,
-			vy: Math.sin(moveAngle) * baseSpeed,
-			speed: baseSpeed,
-			points, springs,
-			boundaryN: N,
-			restArea: computeArea(points, N),
-			color: [66, 165, 245],
-			phase: Math.random() * Math.PI * 2,
-			innerWeights,
-		};
-	}
-
-	function updateBlob(blob: SoftBlob, time: number) {
-		const cellLeft = WALL_MARGIN;
-		const cellRight = WIDTH - WALL_MARGIN;
-		const cellTop = WALL_MARGIN;
-		const cellBottom = HEIGHT - WALL_MARGIN;
-		const N = blob.boundaryN;
-
-		// Step 1: Wall reflection on boundary ring
-		let touchLeft = false, touchRight = false, touchTop = false, touchBottom = false;
-		for (let i = 0; i < N; i++) {
-			const p = blob.points[i];
-			const ax = blob.cx + p.ox, ay = blob.cy + p.oy;
-			if (ax <= cellLeft + 1) touchLeft = true;
-			if (ax >= cellRight - 1) touchRight = true;
-			if (ay <= cellTop + 1) touchTop = true;
-			if (ay >= cellBottom - 1) touchBottom = true;
-		}
-		const prevVx = blob.vx, prevVy = blob.vy;
-		if (touchLeft && blob.vx < 0) blob.vx = Math.abs(blob.vx);
-		if (touchRight && blob.vx > 0) blob.vx = -Math.abs(blob.vx);
-		if (touchTop && blob.vy < 0) blob.vy = Math.abs(blob.vy);
-		if (touchBottom && blob.vy > 0) blob.vy = -Math.abs(blob.vy);
-
-		// On bounce, inject inertia into ring points so they continue pressing
-		// into the wall while the center has already reversed — this is the squish.
-		const dvx = blob.vx - prevVx, dvy = blob.vy - prevVy;
-		if (dvx !== 0 || dvy !== 0) {
-			const inertia = 0.9;
-			for (const p of blob.points) {
-				p.vx -= dvx * inertia;
-				p.vy -= dvy * inertia;
-			}
-		}
-
-		// Step 2: Maintain constant speed
-		const targetSpeed = Math.max(0.05, speed + (blob.speed - 2.5));
-		const mag = Math.sqrt(blob.vx ** 2 + blob.vy ** 2);
-		if (mag > 0.001) {
-			blob.vx = (blob.vx / mag) * targetSpeed;
-			blob.vy = (blob.vy / mag) * targetSpeed;
-		}
-
-		// Step 3: Move center
-		blob.cx += blob.vx;
-		blob.cy += blob.vy;
-		blob.cx = Math.max(cellLeft + 3, Math.min(cellRight - 3, blob.cx));
-		blob.cy = Math.max(cellTop + 3, Math.min(cellBottom - 3, blob.cy));
-
-		// Step 4: Spring forces across entire network
-		for (const s of blob.springs) {
-			const pa = blob.points[s.a], pb = blob.points[s.b];
-			const dx = pb.ox - pa.ox, dy = pb.oy - pa.oy;
-			const d = Math.sqrt(dx * dx + dy * dy) || 0.001;
-			const force = (d - s.restLen) * s.k * stiffness;
-			const fx = (dx / d) * force, fy = (dy / d) * force;
-			pa.vx += fx; pa.vy += fy;
-			pb.vx -= fx; pb.vy -= fy;
-		}
-
-		// Outward pressure on boundary ring only
-		const pulse = 1 + Math.sin(time * 0.0008 + blob.phase) * 0.03;
-		for (let i = 0; i < N; i++) {
-			const p = blob.points[i];
-			const d = Math.sqrt(p.ox * p.ox + p.oy * p.oy) || 0.001;
-			p.vx += (p.ox / d) * pressure * pulse;
-			p.vy += (p.oy / d) * pressure * pulse;
-		}
-
-		// Damping + integrate outer ring only
-		for (let i = 0; i < N; i++) {
-			const p = blob.points[i];
-			p.vx *= damping;
-			p.vy *= damping;
-			p.ox += p.vx;
-			p.oy += p.vy;
-		}
-
-		// Interior nodes: directly derive position from weighted outer ring positions
-		for (let i = N; i < blob.points.length; i++) {
-			const p = blob.points[i];
-			const ws = blob.innerWeights[i - N];
-			let tx = 0, ty = 0;
-			for (let j = 0; j < N; j++) {
-				tx += blob.points[j].ox * ws[j];
-				ty += blob.points[j].oy * ws[j];
-			}
-			p.ox = tx;
-			p.oy = ty;
-			p.vx = 0;
-			p.vy = 0;
-		}
-
-		// Step 5: Clamp outer ring points to walls
-		for (let i = 0; i < N; i++) {
-			const p = blob.points[i];
-			const ax = blob.cx + p.ox, ay = blob.cy + p.oy;
-			if (ax < cellLeft) { p.ox = cellLeft - blob.cx; p.vx = Math.abs(p.vx) * 0.2; }
-			if (ax > cellRight) { p.ox = cellRight - blob.cx; p.vx = -Math.abs(p.vx) * 0.2; }
-			if (ay < cellTop) { p.oy = cellTop - blob.cy; p.vy = Math.abs(p.vy) * 0.2; }
-			if (ay > cellBottom) { p.oy = cellBottom - blob.cy; p.vy = -Math.abs(p.vy) * 0.2; }
-		}
-
-		// Step 6: Directional area conservation (boundary ring only)
-		const wallTol = 2;
-		let squishX = 0, squishY = 0;
-		for (let i = 0; i < N; i++) {
-			const p = blob.points[i];
-			const ax = blob.cx + p.ox, ay = blob.cy + p.oy;
-			if (ax <= cellLeft + wallTol) squishX += 1;
-			if (ax >= cellRight - wallTol) squishX -= 1;
-			if (ay <= cellTop + wallTol) squishY += 1;
-			if (ay >= cellBottom - wallTol) squishY -= 1;
-		}
-		const sqMag = Math.sqrt(squishX * squishX + squishY * squishY);
-		if (sqMag > 0.001) { squishX /= sqMag; squishY /= sqMag; }
-
-		for (let iter = 0; iter < 8; iter++) {
-			const area = computeArea(blob.points, N);
-			const ratio = blob.restArea / Math.max(area, 1);
-			if (Math.abs(ratio - 1) < 0.01) break;
-
-			const baseScale = 1 + (Math.sqrt(ratio) - 1) * 0.25;
-			const correction = (Math.sqrt(ratio) - 1) * 8.0;
-			for (let i = 0; i < blob.points.length; i++) {
-				const p = blob.points[i];
-				const len = Math.sqrt(p.ox * p.ox + p.oy * p.oy) || 0.001;
-				const align = (p.ox * squishX + p.oy * squishY) / len;
-				const boost = 1 + Math.max(0, align) * 1.5;
-				if (i < N) {
-					// Outer ring: direct positional scale (existing behaviour)
-					const ax = blob.cx + p.ox, ay = blob.cy + p.oy;
-					const touching =
-						ax <= cellLeft + wallTol || ax >= cellRight - wallTol ||
-						ay <= cellTop + wallTol || ay >= cellBottom - wallTol;
-					if (!touching) {
-						const scale = 1 + (baseScale - 1) * boost;
-						p.ox *= scale;
-						p.oy *= scale;
-					}
-				} else {
-					// Interior: velocity impulse so they visibly spring with the outer ring
-					p.vx += (p.ox / len) * correction * boost;
-					p.vy += (p.oy / len) * correction * boost;
-				}
-			}
-			for (let i = 0; i < N; i++) {
-				const p = blob.points[i];
-				const ax = blob.cx + p.ox, ay = blob.cy + p.oy;
-				if (ax < cellLeft) p.ox = cellLeft - blob.cx;
-				if (ax > cellRight) p.ox = cellRight - blob.cx;
-				if (ay < cellTop) p.oy = cellTop - blob.cy;
-				if (ay > cellBottom) p.oy = cellBottom - blob.cy;
-			}
-		}
-	}
-
-	function drawBlob(ctx: CanvasRenderingContext2D, blob: SoftBlob) {
-		const [r, g, b] = blob.color;
-		const pts = blob.points;
-		const N = blob.boundaryN;
-
-		let centX = 0, centY = 0;
-		for (let i = 0; i < N; i++) { centX += blob.cx + pts[i].ox; centY += blob.cy + pts[i].oy; }
-		centX /= N; centY /= N;
-
-		let maxDist = 0;
-		for (let i = 0; i < N; i++) {
-			const dx = blob.cx + pts[i].ox - centX, dy = blob.cy + pts[i].oy - centY;
-			const d = dx * dx + dy * dy;
-			if (d > maxDist) maxDist = d;
-		}
-		maxDist = Math.sqrt(maxDist);
-
-		ctx.beginPath();
-		let midX = (blob.cx + pts[0].ox + blob.cx + pts[N - 1].ox) / 2;
-		let midY = (blob.cy + pts[0].oy + blob.cy + pts[N - 1].oy) / 2;
-		ctx.moveTo(midX, midY);
-		for (let i = 0; i < N; i++) {
-			const curr = pts[i], next = pts[(i + 1) % N];
-			const px = blob.cx + curr.ox, py = blob.cy + curr.oy;
-			midX = (px + blob.cx + next.ox) / 2;
-			midY = (py + blob.cy + next.oy) / 2;
-			ctx.quadraticCurveTo(px, py, midX, midY);
-		}
-		ctx.closePath();
-
-		ctx.shadowBlur = 20;
-		ctx.shadowColor = `rgba(${r}, ${g}, ${b}, 0.35)`;
-		const gradR = maxDist * 1.15;
-		const gradient = ctx.createRadialGradient(centX, centY, 0, centX, centY, gradR);
-		gradient.addColorStop(0, `rgba(${r}, ${g}, ${b}, 0.95)`);
-		gradient.addColorStop(0.45, `rgba(${r}, ${g}, ${b}, 0.92)`);
-		gradient.addColorStop(0.7, `rgba(${r}, ${g}, ${b}, 0.75)`);
-		gradient.addColorStop(0.88, `rgba(${r}, ${g}, ${b}, 0.35)`);
-		gradient.addColorStop(1, `rgba(${r}, ${g}, ${b}, 0.05)`);
-		ctx.fillStyle = gradient;
-		ctx.fill();
-		ctx.shadowBlur = 0;
-	}
-
-	function drawMesh(ctx: CanvasRenderingContext2D, blob: SoftBlob) {
-		const pts = blob.points;
-		const N = blob.boundaryN;
-		ctx.save();
-
-		// Clip everything to the blob outline
-		ctx.beginPath();
-		let midX = (blob.cx + pts[0].ox + blob.cx + pts[N - 1].ox) / 2;
-		let midY = (blob.cy + pts[0].oy + blob.cy + pts[N - 1].oy) / 2;
-		ctx.moveTo(midX, midY);
-		for (let i = 0; i < N; i++) {
-			const curr = pts[i], next = pts[(i + 1) % N];
-			const px = blob.cx + curr.ox, py = blob.cy + curr.oy;
-			midX = (px + blob.cx + next.ox) / 2;
-			midY = (py + blob.cy + next.oy) / 2;
-			ctx.quadraticCurveTo(px, py, midX, midY);
-		}
-		ctx.closePath();
-		ctx.clip();
-
-		// All spring edges
-		ctx.strokeStyle = 'rgba(255, 80, 0, 0.45)';
-		ctx.lineWidth = 1.5;
-		for (const s of blob.springs) {
-			ctx.beginPath();
-			ctx.moveTo(blob.cx + pts[s.a].ox, blob.cy + pts[s.a].oy);
-			ctx.lineTo(blob.cx + pts[s.b].ox, blob.cy + pts[s.b].oy);
-			ctx.stroke();
-		}
-
-		// Interior points (smaller, dimmer)
-		ctx.fillStyle = 'rgba(255, 80, 0, 0.6)';
-		for (let i = N; i < pts.length; i++) {
-			ctx.beginPath();
-			ctx.arc(blob.cx + pts[i].ox, blob.cy + pts[i].oy, 4, 0, Math.PI * 2);
-			ctx.fill();
-		}
-
-		// Boundary ring points (larger, bright)
-		ctx.fillStyle = 'rgba(255, 80, 0, 1)';
-		for (let i = 0; i < N; i++) {
-			ctx.beginPath();
-			ctx.arc(blob.cx + pts[i].ox, blob.cy + pts[i].oy, 6, 0, Math.PI * 2);
-			ctx.fill();
-		}
-
-		// Physics center
-		ctx.fillStyle = 'white';
-		ctx.strokeStyle = 'rgba(255, 80, 0, 1)';
-		ctx.lineWidth = 2;
-		ctx.beginPath();
-		ctx.arc(blob.cx, blob.cy, 8, 0, Math.PI * 2);
-		ctx.fill();
-		ctx.stroke();
-
-		ctx.restore();
-	}
-
+	// localStorage persistence
 	const STORAGE_KEY = 'blob-grid-params';
 
 	function saveParams() {
 		try {
 			localStorage.setItem(STORAGE_KEY, JSON.stringify({
-				speed, stiffness, pressure, damping, showMesh, topology, numRing, blobSize, connections, panelOpen
+				speed, springK, pressureK, damping, numRing, numBlobs, showMesh, panelOpen
 			}));
 		} catch { /* storage unavailable */ }
 	}
@@ -478,48 +37,397 @@
 			if (!raw) return;
 			const p = JSON.parse(raw);
 			if (p.speed !== undefined) speed = p.speed;
-			if (p.stiffness !== undefined) stiffness = p.stiffness;
-			if (p.pressure !== undefined) pressure = p.pressure;
+			if (p.springK !== undefined) springK = p.springK;
+			if (p.pressureK !== undefined) pressureK = p.pressureK;
 			if (p.damping !== undefined) damping = p.damping;
-			if (p.showMesh !== undefined) showMesh = p.showMesh;
-			if (p.topology !== undefined) topology = p.topology;
 			if (p.numRing !== undefined) numRing = p.numRing;
-			if (p.blobSize !== undefined) blobSize = p.blobSize;
-			if (p.connections !== undefined) connections = p.connections;
+			if (p.numBlobs !== undefined) numBlobs = p.numBlobs;
+			if (p.showMesh !== undefined) showMesh = p.showMesh;
 			if (p.panelOpen !== undefined) panelOpen = p.panelOpen;
 		} catch { /* corrupt storage */ }
 	}
 
-	$: speed, stiffness, pressure, damping, showMesh, topology, numRing, blobSize, connections, panelOpen, saveParams();
+	$: speed, springK, pressureK, damping, numRing, numBlobs, showMesh, panelOpen, saveParams();
+
+	// Recording
+	let isRecording = false;
+	let recorder: MediaRecorder | null = null;
+	let recordingUrl: string | null = null;
+	let recordingExt = 'webm';
+
+	function startRecording() {
+		if (!canvas) return;
+		const stream = canvas.captureStream(30);
+		const chunks: Blob[] = [];
+		let mimeType = 'video/webm; codecs=vp9';
+		recordingExt = 'webm';
+		if (MediaRecorder.isTypeSupported('video/mp4')) {
+			mimeType = 'video/mp4';
+			recordingExt = 'mp4';
+		}
+		recorder = new MediaRecorder(stream, { mimeType });
+		recorder.ondataavailable = (e) => { if (e.data.size > 0) chunks.push(e.data); };
+		recorder.onstop = () => {
+			const blob = new Blob(chunks, { type: mimeType });
+			if (recordingUrl) URL.revokeObjectURL(recordingUrl);
+			recordingUrl = URL.createObjectURL(blob);
+		};
+		recorder.start();
+		isRecording = true;
+	}
+
+	function stopRecording() {
+		if (recorder && recorder.state === 'recording') recorder.stop();
+		isRecording = false;
+	}
+
+	interface VPoint {
+		x: number; y: number;
+		px: number; py: number;
+	}
+
+	interface SoftBlob {
+		cx: number; cy: number;
+		ring: VPoint[];
+		restLens: number[];
+		bendLens: number[];
+		restArea: number;
+		avgRadius: number;
+		color: [number, number, number];
+	}
+
+	// Color palette — cycled for any blob count
+	const palette: [number, number, number][] = [
+		[66, 165, 245], [210, 175, 140], [230, 110, 95],
+		[200, 40, 100], [235, 210, 55], [148, 128, 200],
+		[80, 75, 68], [45, 100, 220], [155, 168, 28],
+		[160, 118, 78], [210, 170, 200], [115, 188, 198],
+		[100, 58, 28], [0, 210, 155], [200, 28, 28],
+		[180, 80, 180], [90, 200, 90], [255, 160, 60],
+		[60, 60, 160], [200, 200, 80], [140, 80, 60],
+		[80, 180, 220], [220, 120, 180], [120, 160, 80],
+		[180, 140, 200], [100, 200, 180], [200, 80, 60],
+		[60, 140, 120], [220, 180, 120], [140, 100, 180],
+	];
+
+	function polyArea(ring: VPoint[]): number {
+		let area = 0;
+		const n = ring.length;
+		for (let i = 0; i < n; i++) {
+			const j = (i + 1) % n;
+			area += ring[i].x * ring[j].y - ring[j].x * ring[i].y;
+		}
+		return Math.abs(area) / 2;
+	}
+
+	function createBlobs(): SoftBlob[] {
+		const N = numRing;
+		const count = numBlobs;
+		// Arrange in a grid with enough columns to fill the canvas
+		const cols = Math.ceil(Math.sqrt(count * (WIDTH / HEIGHT)));
+		const rows = Math.ceil(count / cols);
+		const baseRadius = Math.min(WIDTH / (cols * 2.5), HEIGHT / (rows * 2.5), 130);
+
+		const blobs: SoftBlob[] = [];
+		for (let idx = 0; idx < count; idx++) {
+			const col = idx % cols;
+			const row = Math.floor(idx / cols);
+			const cx = (col + 0.5) * (WIDTH / cols) + (Math.random() - 0.5) * 40;
+			const cy = (row + 0.5) * (HEIGHT / rows) + (Math.random() - 0.5) * 40;
+			const rot = Math.random() * Math.PI * 2;
+			const moveAngle = Math.random() * Math.PI * 2;
+			const ivx = Math.cos(moveAngle) * speed;
+			const ivy = Math.sin(moveAngle) * speed;
+
+			// Slight size/shape variation per blob
+			const sizeVar = 0.8 + Math.random() * 0.4;
+			const aspectVar = 0.85 + Math.random() * 0.3;
+			const rx = baseRadius * sizeVar * aspectVar;
+			const ry = baseRadius * sizeVar / aspectVar;
+
+			const ring: VPoint[] = [];
+			for (let i = 0; i < N; i++) {
+				const angle = (i / N) * Math.PI * 2 + rot;
+				const c = Math.cos(angle - rot), s = Math.sin(angle - rot);
+				const r = (rx * ry) / Math.sqrt((ry * c) ** 2 + (rx * s) ** 2);
+				const x = cx + Math.cos(angle) * r;
+				const y = cy + Math.sin(angle) * r;
+				ring.push({ x, y, px: x - ivx, py: y - ivy });
+			}
+
+			const restLens: number[] = [];
+			for (let i = 0; i < N; i++) {
+				const j = (i + 1) % N;
+				restLens.push(Math.sqrt((ring[j].x - ring[i].x) ** 2 + (ring[j].y - ring[i].y) ** 2));
+			}
+
+			const bendLens: number[] = [];
+			for (let i = 0; i < N; i++) {
+				const j = (i + 2) % N;
+				bendLens.push(Math.sqrt((ring[j].x - ring[i].x) ** 2 + (ring[j].y - ring[i].y) ** 2));
+			}
+
+			blobs.push({
+				cx, cy,
+				ring, restLens, bendLens,
+				restArea: polyArea(ring),
+				avgRadius: (rx + ry) / 2,
+				color: palette[idx % palette.length],
+			});
+		}
+		return blobs;
+	}
+
+	function updateBlob(blob: SoftBlob) {
+		const N = blob.ring.length;
+		const cellLeft = WALL_MARGIN;
+		const cellRight = WIDTH - WALL_MARGIN;
+		const cellTop = WALL_MARGIN;
+		const cellBottom = HEIGHT - WALL_MARGIN;
+
+		const dt = 1 / SUBSTEPS;
+		for (let step = 0; step < SUBSTEPS; step++) {
+
+			for (const p of blob.ring) {
+				let dx = (p.x - p.px) * damping;
+				let dy = (p.y - p.py) * damping;
+				const spd = Math.sqrt(dx * dx + dy * dy);
+				if (spd > MAX_DISPLACEMENT * dt) {
+					const s = (MAX_DISPLACEMENT * dt) / spd;
+					dx *= s; dy *= s;
+				}
+				p.px = p.x;
+				p.py = p.y;
+				p.x += dx;
+				p.y += dy;
+			}
+
+			const area = polyArea(blob.ring);
+			const P = (pressureK * dt * dt) / Math.max(area, 1);
+			for (let i = 0; i < N; i++) {
+				const j = (i + 1) % N;
+				const pi = blob.ring[i], pj = blob.ring[j];
+				const edgeX = pj.x - pi.x, edgeY = pj.y - pi.y;
+				const edgeLen = Math.sqrt(edgeX * edgeX + edgeY * edgeY) || 0.001;
+				const nx = edgeY / edgeLen, ny = -edgeX / edgeLen;
+				const f = P * edgeLen * 0.5;
+				pi.x += nx * f; pi.y += ny * f;
+				pj.x += nx * f; pj.y += ny * f;
+			}
+
+			const kEdge = springK * dt;
+			for (let i = 0; i < N; i++) {
+				const j = (i + 1) % N;
+				const pi = blob.ring[i], pj = blob.ring[j];
+				const dx = pj.x - pi.x, dy = pj.y - pi.y;
+				const dist = Math.sqrt(dx * dx + dy * dy) || 0.001;
+				const diff = (dist - blob.restLens[i]) / dist;
+				const fx = dx * diff * kEdge * 0.5;
+				const fy = dy * diff * kEdge * 0.5;
+				pi.x += fx; pi.y += fy;
+				pj.x -= fx; pj.y -= fy;
+			}
+
+			const kBend = springK * 0.4 * dt;
+			for (let i = 0; i < N; i++) {
+				const j = (i + 2) % N;
+				const pi = blob.ring[i], pj = blob.ring[j];
+				const dx = pj.x - pi.x, dy = pj.y - pi.y;
+				const dist = Math.sqrt(dx * dx + dy * dy) || 0.001;
+				const diff = (dist - blob.bendLens[i]) / dist;
+				const fx = dx * diff * kBend * 0.5;
+				const fy = dy * diff * kBend * 0.5;
+				pi.x += fx; pi.y += fy;
+				pj.x -= fx; pj.y -= fy;
+			}
+
+			for (const p of blob.ring) {
+				if (p.x < cellLeft) { p.x = cellLeft; if (p.px < cellLeft) p.px = cellLeft; }
+				if (p.x > cellRight) { p.x = cellRight; if (p.px > cellRight) p.px = cellRight; }
+				if (p.y < cellTop) { p.y = cellTop; if (p.py < cellTop) p.py = cellTop; }
+				if (p.y > cellBottom) { p.y = cellBottom; if (p.py > cellBottom) p.py = cellBottom; }
+			}
+		}
+
+		let avgVx = 0, avgVy = 0;
+		for (const p of blob.ring) {
+			avgVx += p.x - p.px;
+			avgVy += p.y - p.py;
+		}
+		avgVx /= N; avgVy /= N;
+
+		const currentSpeed = Math.sqrt(avgVx * avgVx + avgVy * avgVy);
+		if (currentSpeed > 0.0001) {
+			const ratio = speed / currentSpeed;
+			const blend = 0.03;
+			const dvx = avgVx * (ratio - 1) * blend;
+			const dvy = avgVy * (ratio - 1) * blend;
+			for (const p of blob.ring) {
+				p.px -= dvx;
+				p.py -= dvy;
+			}
+		} else {
+			const angle = Math.random() * Math.PI * 2;
+			const push = speed * 0.5;
+			for (const p of blob.ring) {
+				p.px -= Math.cos(angle) * push;
+				p.py -= Math.sin(angle) * push;
+			}
+		}
+
+		blob.cx = 0; blob.cy = 0;
+		for (const p of blob.ring) { blob.cx += p.x; blob.cy += p.y; }
+		blob.cx /= N; blob.cy /= N;
+	}
+
+	function blobPath(ctx: CanvasRenderingContext2D, ring: VPoint[]) {
+		const N = ring.length;
+		ctx.beginPath();
+		let midX = (ring[0].x + ring[N - 1].x) / 2;
+		let midY = (ring[0].y + ring[N - 1].y) / 2;
+		ctx.moveTo(midX, midY);
+		for (let i = 0; i < N; i++) {
+			const curr = ring[i], next = ring[(i + 1) % N];
+			midX = (curr.x + next.x) / 2;
+			midY = (curr.y + next.y) / 2;
+			ctx.quadraticCurveTo(curr.x, curr.y, midX, midY);
+		}
+		ctx.closePath();
+	}
+
+	function drawBlob(ctx: CanvasRenderingContext2D, blob: SoftBlob) {
+		const [r, g, b] = blob.color;
+		const ring = blob.ring;
+		const N = ring.length;
+
+		let centX = 0, centY = 0;
+		for (const p of ring) { centX += p.x; centY += p.y; }
+		centX /= N; centY /= N;
+
+		let maxDX = 0, maxDY = 0;
+		for (const p of ring) {
+			maxDX = Math.max(maxDX, Math.abs(p.x - centX));
+			maxDY = Math.max(maxDY, Math.abs(p.y - centY));
+		}
+
+		ctx.save();
+		ctx.translate(centX, centY);
+		const aspect = maxDX / (maxDY || 1);
+		ctx.scale(aspect, 1);
+
+		const gradR = maxDY * 1.6;
+		const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, gradR);
+		const STOPS = 16;
+		for (let i = 0; i <= STOPS; i++) {
+			const t = i / STOPS;
+			const shifted = Math.max(0, t - 0.45) / 0.55;
+			const alpha = Math.exp(-(shifted * shifted) * 4.5);
+			gradient.addColorStop(t, `rgba(${r}, ${g}, ${b}, ${alpha})`);
+		}
+
+		ctx.fillStyle = gradient;
+		ctx.fillRect(-gradR * 2, -gradR, gradR * 4, gradR * 2);
+		ctx.restore();
+	}
+
+	function drawMesh(ctx: CanvasRenderingContext2D, blob: SoftBlob) {
+		const ring = blob.ring;
+		const N = ring.length;
+
+		ctx.save();
+		ctx.strokeStyle = 'rgba(255, 80, 0, 0.5)';
+		ctx.lineWidth = 1;
+		for (let i = 0; i < N; i++) {
+			const j = (i + 1) % N;
+			ctx.beginPath();
+			ctx.moveTo(ring[i].x, ring[i].y);
+			ctx.lineTo(ring[j].x, ring[j].y);
+			ctx.stroke();
+		}
+
+		ctx.strokeStyle = 'rgba(255, 80, 0, 0.15)';
+		for (let i = 0; i < N; i++) {
+			const j = (i + 2) % N;
+			ctx.beginPath();
+			ctx.moveTo(ring[i].x, ring[i].y);
+			ctx.lineTo(ring[j].x, ring[j].y);
+			ctx.stroke();
+		}
+
+		ctx.fillStyle = 'rgba(255, 80, 0, 1)';
+		for (const p of ring) {
+			ctx.beginPath();
+			ctx.arc(p.x, p.y, 3, 0, Math.PI * 2);
+			ctx.fill();
+		}
+
+		ctx.fillStyle = 'white';
+		ctx.strokeStyle = 'rgba(255, 80, 0, 1)';
+		ctx.lineWidth = 1.5;
+		ctx.beginPath();
+		ctx.arc(blob.cx, blob.cy, 4, 0, Math.PI * 2);
+		ctx.fill();
+		ctx.stroke();
+
+		ctx.restore();
+	}
+
+	function collideBlobs(blobs: SoftBlob[]) {
+		for (let i = 0; i < blobs.length; i++) {
+			for (let j = i + 1; j < blobs.length; j++) {
+				const a = blobs[i], b = blobs[j];
+				const dx = b.cx - a.cx;
+				const dy = b.cy - a.cy;
+				const dist = Math.sqrt(dx * dx + dy * dy) || 0.001;
+				const minDist = a.avgRadius + b.avgRadius;
+
+				if (dist >= minDist) continue;
+
+				const nx = dx / dist, ny = dy / dist;
+				const overlap = minDist - dist;
+				const push = overlap * 0.15;
+
+				for (const p of a.ring) {
+					p.x -= nx * push;
+					p.y -= ny * push;
+				}
+				for (const p of b.ring) {
+					p.x += nx * push;
+					p.y += ny * push;
+				}
+			}
+		}
+	}
 
 	onMount(() => {
 		loadParams();
 		const ctx = canvas.getContext('2d');
 		if (!ctx) return;
 
-		let blob = createBlob(topology);
-		let prevTopology = topology;
+		let blobs = createBlobs();
 		let prevNumRing = numRing;
-		let prevBlobSize = blobSize;
-		let prevConnections = connections;
+		let prevNumBlobs = numBlobs;
 		let animationId: number;
 
 		function animate(time: number) {
-			// Recreate blob when topology or node count changes
-			if (topology !== prevTopology || numRing !== prevNumRing || blobSize !== prevBlobSize || connections !== prevConnections) {
-				blob = createBlob(topology);
-				prevTopology = topology;
+			if (numRing !== prevNumRing || numBlobs !== prevNumBlobs) {
+				blobs = createBlobs();
 				prevNumRing = numRing;
-				prevBlobSize = blobSize;
-				prevConnections = connections;
+				prevNumBlobs = numBlobs;
 			}
 
 			ctx!.fillStyle = BG_COLOR;
 			ctx!.fillRect(0, 0, WIDTH, HEIGHT);
 
-			updateBlob(blob, time);
-			drawBlob(ctx!, blob);
-			if (showMesh) drawMesh(ctx!, blob);
+			for (const blob of blobs) {
+				updateBlob(blob);
+			}
+			collideBlobs(blobs);
+
+			for (const blob of blobs) {
+				drawBlob(ctx!, blob);
+				if (showMesh) drawMesh(ctx!, blob);
+			}
 
 			animationId = requestAnimationFrame(animate);
 		}
@@ -538,7 +446,16 @@
 		style="aspect-ratio: 9 / 16;"
 	/>
 
-	<div class="absolute top-2 right-2 z-10">
+	<div class="absolute top-2 right-2 z-10 flex gap-2 items-start">
+		<button
+			class="rounded-md shadow-lg px-3 py-1.5 text-sm font-bold"
+			class:bg-red-500={isRecording}
+			class:text-white={isRecording}
+			class:bg-surface={!isRecording}
+			on:click={() => isRecording ? stopRecording() : startRecording()}
+		>
+			{isRecording ? 'Stop' : 'Record'}
+		</button>
 		<button
 			class="bg-surface rounded-md shadow-lg px-3 py-1.5 text-sm font-bold"
 			on:click={() => (panelOpen = !panelOpen)}
@@ -547,63 +464,37 @@
 		</button>
 
 		{#if panelOpen}
-			<div class="mt-2 w-[220px] bg-surface rounded-md shadow-lg p-4">
+			<div class="mt-2 w-[220px] bg-surface rounded-md shadow-lg p-4 max-h-[80vh] overflow-y-auto">
 				<div class="flex flex-col my-2.5">
-					<label for="param-size" class="text-xs font-bold">Size</label>
-					<input id="param-size" type="range" min={50} max={500} step={5} bind:value={blobSize} class="w-full rounded !text-md px-2 py-1" />
-					<span class="text-xs text-neutral-500">{blobSize}</span>
+					<label for="param-blobs" class="text-xs font-bold">Blobs</label>
+					<input id="param-blobs" type="range" min={1} max={50} step={1} bind:value={numBlobs} class="w-full" />
+					<span class="text-xs text-neutral-500">{numBlobs}</span>
 				</div>
-
-				<div class="flex flex-col my-2.5">
-					<label for="param-nodes" class="text-xs font-bold">Nodes</label>
-					<input id="param-nodes" type="range" min={6} max={48} step={1} bind:value={numRing} class="w-full rounded !text-md px-2 py-1" />
-					<span class="text-xs text-neutral-500">{numRing}</span>
-				</div>
-
-				<div class="flex flex-col my-2.5">
-					<label for="param-connections" class="text-xs font-bold">Connections</label>
-					<input id="param-connections" type="range" min={1} max={8} step={1} bind:value={connections} class="w-full rounded !text-md px-2 py-1" />
-					<span class="text-xs text-neutral-500">{connections}</span>
-				</div>
-
-				<div class="flex flex-col my-2.5">
-					<label for="param-topology" class="text-xs font-bold">Topology</label>
-					<select
-						id="param-topology"
-						bind:value={topology}
-						class="w-full rounded text-sm px-2 py-1 mt-1 bg-surface border border-neutral-300"
-					>
-						<option value="spokes">Spokes (original)</option>
-						<option value="rings">Rings</option>
-						<option value="cross">Cross</option>
-						<option value="grid">Grid</option>
-					</select>
-				</div>
-
 				<div class="flex flex-col my-2.5">
 					<label for="param-speed" class="text-xs font-bold">Speed</label>
-					<input id="param-speed" type="range" min={0.05} max={10} step={0.05} bind:value={speed} class="w-full rounded !text-md px-2 py-1" />
+					<input id="param-speed" type="range" min={0.05} max={5} step={0.05} bind:value={speed} class="w-full" />
 					<span class="text-xs text-neutral-500">{speed.toFixed(2)}</span>
 				</div>
-
 				<div class="flex flex-col my-2.5">
-					<label for="param-stiffness" class="text-xs font-bold">Stiffness</label>
-					<input id="param-stiffness" type="range" min={0.0005} max={0.1} step={0.0005} bind:value={stiffness} class="w-full rounded !text-md px-2 py-1" />
-					<span class="text-xs text-neutral-500">{stiffness.toFixed(4)}</span>
+					<label for="param-springK" class="text-xs font-bold">Spring K</label>
+					<input id="param-springK" type="range" min={0.01} max={1} step={0.01} bind:value={springK} class="w-full" />
+					<span class="text-xs text-neutral-500">{springK.toFixed(2)}</span>
 				</div>
-
 				<div class="flex flex-col my-2.5">
 					<label for="param-pressure" class="text-xs font-bold">Pressure</label>
-					<input id="param-pressure" type="range" min={0} max={0.9} step={0.001} bind:value={pressure} class="w-full rounded !text-md px-2 py-1" />
-					<span class="text-xs text-neutral-500">{pressure.toFixed(4)}</span>
+					<input id="param-pressure" type="range" min={50} max={10000} step={50} bind:value={pressureK} class="w-full" />
+					<span class="text-xs text-neutral-500">{pressureK}</span>
 				</div>
-
 				<div class="flex flex-col my-2.5">
 					<label for="param-damping" class="text-xs font-bold">Damping</label>
-					<input id="param-damping" type="range" min={0.8} max={0.99} step={0.005} bind:value={damping} class="w-full rounded !text-md px-2 py-1" />
+					<input id="param-damping" type="range" min={0.95} max={1} step={0.001} bind:value={damping} class="w-full" />
 					<span class="text-xs text-neutral-500">{damping.toFixed(3)}</span>
 				</div>
-
+				<div class="flex flex-col my-2.5">
+					<label for="param-ring" class="text-xs font-bold">Ring Nodes</label>
+					<input id="param-ring" type="range" min={12} max={48} step={1} bind:value={numRing} class="w-full" />
+					<span class="text-xs text-neutral-500">{numRing}</span>
+				</div>
 				<div class="flex items-center gap-2 my-2.5">
 					<input id="param-mesh" type="checkbox" bind:checked={showMesh} />
 					<label for="param-mesh" class="text-xs font-bold">Show mesh</label>
@@ -611,4 +502,22 @@
 			</div>
 		{/if}
 	</div>
+
+	{#if recordingUrl}
+		<div class="absolute bottom-2 right-2 z-10 bg-surface rounded-md shadow-lg p-3 flex gap-2 items-center">
+			<a
+				href={recordingUrl}
+				download={`blob-grid.${recordingExt}`}
+				class="text-sm font-bold underline"
+			>
+				Download .{recordingExt}
+			</a>
+			<button
+				class="text-xs text-neutral-500"
+				on:click={() => { if (recordingUrl) URL.revokeObjectURL(recordingUrl); recordingUrl = null; }}
+			>
+				dismiss
+			</button>
+		</div>
+	{/if}
 </div>

--- a/packages/ui/src/lib/state/post-control.ts
+++ b/packages/ui/src/lib/state/post-control.ts
@@ -88,7 +88,15 @@ export class PostControlContext extends EventTarget {
 	}
 
 	public captureRecording(stream: MediaStream) {
-		const recorder = new MediaRecorder(stream, { mimeType: 'video/webm; codecs=vp9' });
+		// Prefer MP4 (Safari + recent Chrome), fall back to WebM
+		let mimeType = 'video/webm; codecs=vp9';
+		let blobType = 'video/webm';
+		if (MediaRecorder.isTypeSupported('video/mp4')) {
+			mimeType = 'video/mp4';
+			blobType = 'video/mp4';
+		}
+
+		const recorder = new MediaRecorder(stream, { mimeType });
 		const chunks = new Array<Blob>();
 
 		recorder.ondataavailable = ({ data }) => {
@@ -96,7 +104,7 @@ export class PostControlContext extends EventTarget {
 		};
 
 		recorder.onstop = () => {
-			const blob = new Blob(chunks, { type: 'video/webm' });
+			const blob = new Blob(chunks, { type: blobType });
 			const link = URL.createObjectURL(blob);
 			this.dispatchEvent(new RecordingCompleteEvent(link));
 		};


### PR DESCRIPTION
## Summary

- **New entry: blob-convergence** — fragment shader (BookOfShadersContent) with metaball-style Gaussian field rendering, Verlet soft-body physics, Matyka edge-normal pressure model, and visual blob merging (color convergence when blobs overlap)
- **blob-grid improvements** — rewrite physics to fully autonomous Verlet ring points (no rigid center), Gaussian gradient rendering, MP4/WebM recording, free-roaming blobs with inter-blob collision
- **MP4 recording** — PostControlBar now prefers MP4 format (native Safari/Chrome), falls back to WebM
- **Param value display** — range sliders now show their current numeric value

## Key files

| File | Purpose |
|------|---------|
| `packages/ui/src/lib/entries/blob-convergence.ts` | New shader entry with physics + GLSL metaball rendering |
| `packages/ui/src/lib/explorations/blob-grid.svelte` | Improved canvas-based blob sim with recording |
| `packages/ui/src/lib/state/post-control.ts` | MP4-preferred recording |
| `packages/ui/src/lib/components/content-params/ParamInput.svelte` | Value display for range sliders |

## Test plan

- [ ] Verify blob-convergence entry loads and renders blobs with soft edges
- [ ] Test param sliders (blobs, speed, spring K, pressure, damping, ring nodes, color bleed, show mesh)
- [ ] Test recording produces MP4 on Safari, WebM on Firefox
- [ ] Verify blob-grid entry still works with updated physics

🤖 Generated with [Claude Code](https://claude.com/claude-code)