### PR TITLE
Add colorful abstract S favicon

### DIFF
--- a/packages/ui/src/app.html
+++ b/packages/ui/src/app.html
@@ -2,7 +2,8 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.svg" type="image/svg+xml" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" sizes="32x32" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<link rel="preconnect" href="https://fonts.googleapis.com" />
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/packages/ui/static/favicon.svg
+++ b/packages/ui/static/favicon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#fce7f3"/>
+  <!-- Pink → orange → teal → indigo -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ec4899"/>
+      <stop offset="33%" stop-color="#f97316"/>
+      <stop offset="66%" stop-color="#14b8a6"/>
+      <stop offset="100%" stop-color="#6366f1"/>
+    </linearGradient>
+  </defs>
+  <path d="M22 4c-7 0-9 5-9 7.5s5 4.5 5 7.5c0 4-3 9-9 9"
+        fill="none" stroke="url(#g)" stroke-width="5.5" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary
- New SVG favicon: fluid abstract S with pink→orange→teal→indigo gradient on light pink background
- SVG as primary favicon, old PNG kept as fallback for older browsers

## Test plan
- [ ] Verify favicon renders in browser tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)