### PR TITLE
Improve mobile usability of sliders and input controls

### DIFF
--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -65,6 +65,8 @@
 		background: var(--range-track);
 		outline: none;
 		touch-action: none;
+		user-select: none;
+		-webkit-touch-callout: none;
 	}
 	input[type='range']::-webkit-slider-thumb {
 		-webkit-appearance: none;
@@ -93,17 +95,17 @@
 		input[type='range'] {
 			height: 8px;
 			border-radius: 4px;
-			padding: 14px 0;
+			padding: 10px 0;
 			box-sizing: content-box;
 			background-clip: content-box;
 		}
 		input[type='range']::-webkit-slider-thumb {
-			width: 36px;
-			height: 36px;
+			width: 28px;
+			height: 28px;
 		}
 		input[type='range']::-moz-range-thumb {
-			width: 36px;
-			height: 36px;
+			width: 28px;
+			height: 28px;
 		}
 		input[type='range']::-moz-range-track {
 			height: 8px;

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -64,19 +64,20 @@
 		border-radius: 3px;
 		background: var(--range-track);
 		outline: none;
+		touch-action: none;
 	}
 	input[type='range']::-webkit-slider-thumb {
 		-webkit-appearance: none;
 		appearance: none;
-		width: 18px;
-		height: 18px;
+		width: 22px;
+		height: 22px;
 		border-radius: 50%;
 		background: var(--range-thumb);
 		cursor: pointer;
 	}
 	input[type='range']::-moz-range-thumb {
-		width: 18px;
-		height: 18px;
+		width: 22px;
+		height: 22px;
 		border-radius: 50%;
 		background: var(--range-thumb);
 		cursor: pointer;
@@ -86,5 +87,32 @@
 		height: 6px;
 		border-radius: 3px;
 		background: var(--range-track);
+	}
+
+	@media (pointer: coarse) {
+		input[type='range'] {
+			height: 8px;
+			border-radius: 4px;
+			padding: 14px 0;
+			box-sizing: content-box;
+			background-clip: content-box;
+		}
+		input[type='range']::-webkit-slider-thumb {
+			width: 36px;
+			height: 36px;
+		}
+		input[type='range']::-moz-range-thumb {
+			width: 36px;
+			height: 36px;
+		}
+		input[type='range']::-moz-range-track {
+			height: 8px;
+			border-radius: 4px;
+		}
+		input[type='number'],
+		select {
+			min-height: 44px;
+			font-size: 16px;
+		}
 	}
 }

--- a/packages/ui/src/lib/components/ContentRendererStage.svelte
+++ b/packages/ui/src/lib/components/ContentRendererStage.svelte
@@ -3,7 +3,7 @@
 
 	import { type Post, type PostContent, type StageContent } from '@sc/model';
 	import { Stage } from 'grraf';
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	import { PlayState, PlayStateChangedEvent, PostControlContext } from '$lib/state/post-control';
 
 	interface Props {
@@ -15,6 +15,7 @@
 	let { post = undefined, container = undefined, cnv = undefined }: Props = $props();
 
 	let content = $derived(post?.content() as StageContent | undefined);
+	let stage: Stage | undefined;
 
 	const ctx = getContext('post-control') as PostControlContext;
 
@@ -40,9 +41,25 @@
 		}
 	});
 
+	function handleResize() {
+		if (stage && container) {
+			stage.canvas.height = container.clientHeight;
+			stage.canvas.width = container.clientWidth;
+		}
+	}
+
+	onMount(() => {
+		let observer: ResizeObserver | undefined;
+		if (container) {
+			observer = new ResizeObserver(handleResize);
+			observer.observe(container);
+		}
+		return () => observer?.disconnect();
+	});
+
 	run(() => {
 		if (cnv) {
-			const stage: Stage | undefined = new Stage(cnv!);
+			stage = new Stage(cnv!);
 
 			stage.canvas.height = container!.clientHeight;
 			stage.canvas.width = container!.clientWidth;

--- a/packages/ui/src/lib/components/ContentRendererThree.svelte
+++ b/packages/ui/src/lib/components/ContentRendererThree.svelte
@@ -34,13 +34,8 @@
 		const { camera, renderer } = renderParams;
 		const parent = canvas.parentElement;
 		if (renderer && canvas && parent && camera) {
-			/* Collapse canvas so it doesn't inflate the parent's measured size */
-			canvas.style.width = '0';
-			canvas.style.height = '0';
 			const width = parent.clientWidth;
 			const height = parent.clientHeight;
-			canvas.style.width = '';
-			canvas.style.height = '';
 			res.x = width;
 			res.y = height;
 			canvas.width = width;
@@ -97,8 +92,17 @@
 
 	onMount(() => {
 		document.addEventListener('fullscreenchange', onFullscreenChange);
+
+		let observer: ResizeObserver | undefined;
+		const parent = cnv?.parentElement;
+		if (parent) {
+			observer = new ResizeObserver(handleResize);
+			observer.observe(parent);
+		}
+
 		return () => {
 			document.removeEventListener('fullscreenchange', onFullscreenChange);
+			observer?.disconnect();
 			content?.stop();
 		};
 	});
@@ -124,7 +128,6 @@
 					container: cnv.parentElement as HTMLElement
 				};
 
-				window.addEventListener('resize', handleResize);
 				handleResize();
 				content.start(renderParams);
 				isRunning = true;

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -10,6 +10,7 @@
 	import { PlayState, PostControlContext } from '$lib/state/post-control';
 	import type { ContentParams } from '$lib/content-params';
 	import PostParams from '$lib/components/PostParams.svelte';
+	import { compactNav } from '$lib/state/layout';
 
 	const postControlContext = new PostControlContext({
 		playState: PlayState.playing,
@@ -30,6 +31,11 @@
 	let requiresCanvas = $derived(
 		post?.summary?.type === PostType.experiment || post?.summary?.type === PostType.experiment3d
 	);
+
+	$effect(() => {
+		compactNav.set(!!requiresCanvas);
+		return () => compactNav.set(false);
+	});
 
 	let container: HTMLDivElement | undefined = $state(undefined);
 	let cnv: HTMLCanvasElement | undefined = $state(undefined);
@@ -115,20 +121,21 @@
 
 <div class="flex flex-1 flex-col h-full" class:experiment-layout={requiresCanvas}>
 	{#if !hideHeader}
-		<div class="post-header" class:experiment-header={requiresCanvas}>
+		<!-- Full header: desktop always, mobile for non-experiments -->
+		<div class="post-header" class:experiment-header-full={requiresCanvas}>
 			<a
 				href="/"
 				class="text-sm text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors"
 				>← journal</a
 			>
-			<div class="flex flex-row items-baseline mt-1">
+			<div class="flex flex-row items-baseline mt-2">
 				<h1 class="flex-1">{title}</h1>
 				<div>
 					{date?.toLocaleDateString()}
 				</div>
 			</div>
 			{#if post?.summary.collaborators?.length}
-				<div class="flex flex-wrap gap-x-4 gap-y-1 mb-1 -mt-1">
+				<div class="flex flex-wrap gap-x-4 gap-y-1 mb-3 -mt-1">
 					{#each post.summary.collaborators as collab}
 						<span class="text-sm text-theme-text-secondary">
 							{collab.role}:
@@ -148,6 +155,19 @@
 				</div>
 			{/if}
 		</div>
+
+		<!-- Compact header: mobile experiments only -->
+		{#if requiresCanvas}
+			<div class="experiment-header-compact flex-shrink-0">
+				<a
+					href="/"
+					class="text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors shrink-0"
+					>←</a
+				>
+				<span class="text-base font-semibold truncate flex-1">{title}</span>
+				<span class="text-xs text-theme-text-muted shrink-0">{date?.toLocaleDateString()}</span>
+			</div>
+		{/if}
 	{/if}
 
 	<div
@@ -186,29 +206,27 @@
 
 <style>
 	.experiment-layout {
-		position: relative;
 		height: calc(100dvh - 6.25rem);
+	}
+
+	.experiment-header-compact {
+		display: none;
 	}
 
 	@media (max-width: 639px) {
 		.experiment-layout {
-			height: calc(100dvh - 4.25rem);
+			height: calc(100dvh - 0.75rem);
 		}
 
-		.experiment-header {
-			position: absolute;
-			top: 0;
-			left: 0;
-			right: 0;
-			z-index: 10;
-			padding-bottom: 1.5rem;
-			background: linear-gradient(to bottom, var(--color-bg) 40%, transparent);
-			pointer-events: none;
+		.experiment-header-full {
+			display: none;
 		}
 
-		.experiment-header :global(a),
-		.experiment-header :global(button) {
-			pointer-events: auto;
+		.experiment-header-compact {
+			display: flex;
+			align-items: baseline;
+			gap: 0.5rem;
+			padding: 0.25rem 0;
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -10,6 +10,7 @@
 	import { PlayState, PostControlContext } from '$lib/state/post-control';
 	import type { ContentParams } from '$lib/content-params';
 	import PostParams from '$lib/components/PostParams.svelte';
+	import Icon from '$lib/components/icons/Icon.svelte';
 	import { compactNav } from '$lib/state/layout';
 
 	const postControlContext = new PostControlContext({
@@ -181,10 +182,8 @@
 		<!-- Compact header: mobile experiments only -->
 		{#if requiresCanvas}
 			<div class="experiment-header-compact flex-shrink-0">
-				<a
-					href="/"
-					class="flex items-center justify-center text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors shrink-0 back-btn"
-					>←</a
+				<a href="/" class="flex items-center justify-center no-underline shrink-0 back-btn"
+					><Icon type="chevron-left" size="sm" className="!text-inherit hover:!text-inherit" /></a
 				>
 				<span class="text-sm font-semibold truncate flex-1">{title}</span>
 				<span class="text-xs text-theme-text-muted shrink-0">{date?.toLocaleDateString()}</span>
@@ -266,7 +265,12 @@
 			width: 2.75rem;
 			height: 2.75rem;
 			margin-left: -0.75rem;
-			font-size: 1.125rem;
+			color: var(--color-text-secondary);
+			transition: color 0.15s;
+		}
+
+		.experiment-header-compact .back-btn:hover {
+			color: var(--color-text-heading);
 		}
 
 		.control-area {

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -168,7 +168,7 @@
 	</div>
 
 	{#if requiresCanvas}
-		<div class="relative flex-shrink-0" bind:this={controlArea}>
+		<div class="flex-shrink-0 flex flex-col" bind:this={controlArea}>
 			{#if areParamsOpen && post && post.params}
 				<PostParams params={post.params} {onParamsChange} />
 			{/if}

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -113,7 +113,7 @@
 	});
 </script>
 
-<div class="flex flex-1 flex-col h-full">
+<div class="flex flex-1 flex-col h-full" class:experiment-layout={requiresCanvas}>
 	{#if !hideHeader}
 		<a
 			href="/"
@@ -148,7 +148,10 @@
 		{/if}
 	{/if}
 
-	<div bind:this={container} class="flex flex-1 relative min-h-[80vh]">
+	<div
+		bind:this={container}
+		class={`flex flex-1 relative ${requiresCanvas ? 'min-h-0' : 'min-h-[80vh]'}`}
+	>
 		{#if requiresCanvas}
 			<canvas bind:this={cnv}>your browser does not support HTML canvas :(</canvas>
 		{/if}
@@ -165,7 +168,7 @@
 	</div>
 
 	{#if requiresCanvas}
-		<div class="relative" bind:this={controlArea}>
+		<div class="relative flex-shrink-0" bind:this={controlArea}>
 			{#if areParamsOpen && post && post.params}
 				<PostParams params={post.params} {onParamsChange} />
 			{/if}
@@ -178,3 +181,15 @@
 		</div>
 	{/if}
 </div>
+
+<style>
+	.experiment-layout {
+		height: calc(100dvh - 6.25rem);
+	}
+
+	@media (max-width: 639px) {
+		.experiment-layout {
+			height: calc(100dvh - 4.25rem);
+		}
+	}
+</style>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -161,7 +161,7 @@
 			<div class="experiment-header-compact flex-shrink-0">
 				<a
 					href="/"
-					class="text-sm text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors shrink-0"
+					class="flex items-center justify-center text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors shrink-0 back-btn"
 					>←</a
 				>
 				<span class="text-sm font-semibold truncate flex-1">{title}</span>
@@ -190,7 +190,7 @@
 	</div>
 
 	{#if requiresCanvas}
-		<div class="flex-shrink-0 flex flex-col" bind:this={controlArea}>
+		<div class="flex-shrink-0 flex flex-col control-area" bind:this={controlArea}>
 			{#if areParamsOpen && post && post.params}
 				<PostParams params={post.params} {onParamsChange} />
 			{/if}
@@ -226,8 +226,21 @@
 		.experiment-header-compact {
 			display: flex;
 			align-items: center;
-			gap: 0.5rem;
-			padding: 0.25rem 0;
+			gap: 0.25rem;
+			height: 2.75rem;
+			margin: 0 -0.75rem;
+			padding: 0 0.75rem;
+		}
+
+		.experiment-header-compact .back-btn {
+			width: 2.75rem;
+			height: 2.75rem;
+			margin-left: -0.75rem;
+			font-size: 1.125rem;
+		}
+
+		.control-area {
+			margin: 0 -0.75rem -0.5rem;
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -133,8 +133,11 @@
 		}
 	}
 
+	let hasLoadedSavedParams = false;
+
 	run(() => {
-		if (post?.params) {
+		if (post?.params && !hasLoadedSavedParams) {
+			hasLoadedSavedParams = true;
 			const saved = loadSavedParams();
 			if (saved) {
 				post = { ...post, params: saved };

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -194,7 +194,7 @@
 
 	<div
 		bind:this={container}
-		class={`flex flex-1 relative ${requiresCanvas ? 'min-h-0' : 'min-h-[80vh]'}`}
+		class={`flex flex-1 relative ${requiresCanvas ? 'min-h-0 overflow-hidden' : 'min-h-[80vh]'}`}
 	>
 		{#if requiresCanvas}
 			<canvas bind:this={cnv}>your browser does not support HTML canvas :(</canvas>
@@ -269,8 +269,6 @@
 
 		.control-area {
 			margin: 0 -0.75rem -0.5rem;
-			position: relative;
-			z-index: 10;
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -115,37 +115,39 @@
 
 <div class="flex flex-1 flex-col h-full" class:experiment-layout={requiresCanvas}>
 	{#if !hideHeader}
-		<a
-			href="/"
-			class="text-sm text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors"
-			>← journal</a
-		>
-		<div class="flex flex-row items-baseline mt-2">
-			<h1 class="flex-1">{title}</h1>
-			<div>
-				{date?.toLocaleDateString()}
+		<div class="post-header" class:experiment-header={requiresCanvas}>
+			<a
+				href="/"
+				class="text-sm text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors"
+				>← journal</a
+			>
+			<div class="flex flex-row items-baseline mt-1">
+				<h1 class="flex-1">{title}</h1>
+				<div>
+					{date?.toLocaleDateString()}
+				</div>
 			</div>
+			{#if post?.summary.collaborators?.length}
+				<div class="flex flex-wrap gap-x-4 gap-y-1 mb-1 -mt-1">
+					{#each post.summary.collaborators as collab}
+						<span class="text-sm text-theme-text-secondary">
+							{collab.role}:
+							{#if collab.url}
+								<a
+									href={collab.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="underline underline-offset-2 hover:text-theme-text-heading transition-colors"
+									>{collab.name}</a
+								>
+							{:else}
+								{collab.name}
+							{/if}
+						</span>
+					{/each}
+				</div>
+			{/if}
 		</div>
-		{#if post?.summary.collaborators?.length}
-			<div class="flex flex-wrap gap-x-4 gap-y-1 mb-3 -mt-1">
-				{#each post.summary.collaborators as collab}
-					<span class="text-sm text-theme-text-secondary">
-						{collab.role}:
-						{#if collab.url}
-							<a
-								href={collab.url}
-								target="_blank"
-								rel="noopener noreferrer"
-								class="underline underline-offset-2 hover:text-theme-text-heading transition-colors"
-								>{collab.name}</a
-							>
-						{:else}
-							{collab.name}
-						{/if}
-					</span>
-				{/each}
-			</div>
-		{/if}
 	{/if}
 
 	<div
@@ -184,12 +186,29 @@
 
 <style>
 	.experiment-layout {
+		position: relative;
 		height: calc(100dvh - 6.25rem);
 	}
 
 	@media (max-width: 639px) {
 		.experiment-layout {
 			height: calc(100dvh - 4.25rem);
+		}
+
+		.experiment-header {
+			position: absolute;
+			top: 0;
+			left: 0;
+			right: 0;
+			z-index: 10;
+			padding-bottom: 1.5rem;
+			background: linear-gradient(to bottom, var(--color-bg) 40%, transparent);
+			pointer-events: none;
+		}
+
+		.experiment-header :global(a),
+		.experiment-header :global(button) {
+			pointer-events: auto;
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -42,7 +42,6 @@
 	let controlArea: HTMLDivElement | undefined = $state(undefined);
 	let areParamsOpen = $state(false);
 	let paramsSnapshot: ContentParams | undefined = $state(undefined);
-	let pendingParams: ContentParams | undefined = $state(undefined);
 
 	function onDocumentClick(e: MouseEvent) {
 		if (areParamsOpen && controlArea && !controlArea.contains(e.target as Node)) {
@@ -88,25 +87,20 @@
 
 	function onParamsPreview(params: ContentParams) {
 		postControlContext.setParams(params);
-		pendingParams = params;
 	}
 
-	function saveParams() {
-		const paramsToSave = pendingParams ?? post?.params;
-		if (paramsToSave) {
-			const key = getParamsStorageKey();
-			if (key) {
-				try {
-					const data = paramsToSave.map((p) => ({ id: p.id, value: p.value }));
-					localStorage.setItem(key, JSON.stringify(data));
-				} catch {
-					/* storage full or unavailable */
-				}
+	function saveParams(params: ContentParams) {
+		const key = getParamsStorageKey();
+		if (key) {
+			try {
+				const data = params.map((p) => ({ id: p.id, value: p.value }));
+				localStorage.setItem(key, JSON.stringify(data));
+			} catch {
+				/* storage full or unavailable */
 			}
 		}
 		areParamsOpen = false;
 		paramsSnapshot = undefined;
-		pendingParams = undefined;
 	}
 
 	function cancelParams() {
@@ -115,7 +109,6 @@
 		}
 		areParamsOpen = false;
 		paramsSnapshot = undefined;
-		pendingParams = undefined;
 	}
 
 	function loadSavedParams(): ContentParams | undefined {

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -41,10 +41,11 @@
 	let cnv: HTMLCanvasElement | undefined = $state(undefined);
 	let controlArea: HTMLDivElement | undefined = $state(undefined);
 	let areParamsOpen = $state(false);
+	let paramsSnapshot: ContentParams | undefined = $state(undefined);
 
 	function onDocumentClick(e: MouseEvent) {
 		if (areParamsOpen && controlArea && !controlArea.contains(e.target as Node)) {
-			areParamsOpen = false;
+			cancelParams();
 		}
 	}
 
@@ -72,24 +73,48 @@
 	}
 
 	function toggleParams() {
-		areParamsOpen = !areParamsOpen;
+		if (!areParamsOpen && post?.params) {
+			paramsSnapshot = post.params.map((p) => ({ ...p }));
+			areParamsOpen = true;
+		} else {
+			cancelParams();
+		}
 	}
 
 	function getParamsStorageKey(): string | undefined {
 		return post?.summary?.id ? `post-params:${post.summary.id}` : undefined;
 	}
 
-	function onParamsChange(params: ContentParams) {
+	function onParamsPreview(params: ContentParams) {
 		postControlContext.setParams(params);
-		const key = getParamsStorageKey();
-		if (key) {
-			try {
-				const data = params.map((p) => ({ id: p.id, value: p.value }));
-				localStorage.setItem(key, JSON.stringify(data));
-			} catch {
-				/* storage full or unavailable */
+		if (post) {
+			post = { ...post, params };
+		}
+	}
+
+	function saveParams() {
+		if (post?.params) {
+			const key = getParamsStorageKey();
+			if (key) {
+				try {
+					const data = post.params.map((p) => ({ id: p.id, value: p.value }));
+					localStorage.setItem(key, JSON.stringify(data));
+				} catch {
+					/* storage full or unavailable */
+				}
 			}
 		}
+		areParamsOpen = false;
+		paramsSnapshot = undefined;
+	}
+
+	function cancelParams() {
+		if (paramsSnapshot && post) {
+			post = { ...post, params: paramsSnapshot };
+			postControlContext.setParams(paramsSnapshot);
+		}
+		areParamsOpen = false;
+		paramsSnapshot = undefined;
 	}
 
 	function loadSavedParams(): ContentParams | undefined {
@@ -192,14 +217,20 @@
 	{#if requiresCanvas}
 		<div class="flex-shrink-0 flex flex-col control-area" bind:this={controlArea}>
 			{#if areParamsOpen && post && post.params}
-				<PostParams params={post.params} {onParamsChange} />
+				<PostParams
+					params={post.params}
+					onParamsChange={onParamsPreview}
+					onSave={saveParams}
+					onCancel={cancelParams}
+				/>
+			{:else}
+				<PostControlBar
+					{toggleFullScreen}
+					postId={post?.summary.id}
+					hasParams={Boolean(post?.params)}
+					{toggleParams}
+				/>
 			{/if}
-			<PostControlBar
-				{toggleFullScreen}
-				postId={post?.summary.id}
-				hasParams={Boolean(post?.params)}
-				{toggleParams}
-			/>
 		</div>
 	{/if}
 </div>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -276,6 +276,8 @@
 
 		.control-area {
 			margin: 0 -0.75rem -0.5rem;
+			position: relative;
+			z-index: 10;
 		}
 	}
 </style>

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -161,10 +161,10 @@
 			<div class="experiment-header-compact flex-shrink-0">
 				<a
 					href="/"
-					class="text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors shrink-0"
+					class="text-sm text-theme-text-muted hover:text-theme-text-secondary no-underline transition-colors shrink-0"
 					>←</a
 				>
-				<span class="text-base font-semibold truncate flex-1">{title}</span>
+				<span class="text-sm font-semibold truncate flex-1">{title}</span>
 				<span class="text-xs text-theme-text-muted shrink-0">{date?.toLocaleDateString()}</span>
 			</div>
 		{/if}
@@ -206,6 +206,7 @@
 
 <style>
 	.experiment-layout {
+		flex: none;
 		height: calc(100dvh - 6.25rem);
 	}
 
@@ -224,7 +225,7 @@
 
 		.experiment-header-compact {
 			display: flex;
-			align-items: baseline;
+			align-items: center;
 			gap: 0.5rem;
 			padding: 0.25rem 0;
 		}

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -42,6 +42,7 @@
 	let controlArea: HTMLDivElement | undefined = $state(undefined);
 	let areParamsOpen = $state(false);
 	let paramsSnapshot: ContentParams | undefined = $state(undefined);
+	let pendingParams: ContentParams | undefined = $state(undefined);
 
 	function onDocumentClick(e: MouseEvent) {
 		if (areParamsOpen && controlArea && !controlArea.contains(e.target as Node)) {
@@ -87,17 +88,16 @@
 
 	function onParamsPreview(params: ContentParams) {
 		postControlContext.setParams(params);
-		if (post) {
-			post = { ...post, params };
-		}
+		pendingParams = params;
 	}
 
 	function saveParams() {
-		if (post?.params) {
+		const paramsToSave = pendingParams ?? post?.params;
+		if (paramsToSave) {
 			const key = getParamsStorageKey();
 			if (key) {
 				try {
-					const data = post.params.map((p) => ({ id: p.id, value: p.value }));
+					const data = paramsToSave.map((p) => ({ id: p.id, value: p.value }));
 					localStorage.setItem(key, JSON.stringify(data));
 				} catch {
 					/* storage full or unavailable */
@@ -106,15 +106,16 @@
 		}
 		areParamsOpen = false;
 		paramsSnapshot = undefined;
+		pendingParams = undefined;
 	}
 
 	function cancelParams() {
-		if (paramsSnapshot && post) {
-			post = { ...post, params: paramsSnapshot };
+		if (paramsSnapshot) {
 			postControlContext.setParams(paramsSnapshot);
 		}
 		areParamsOpen = false;
 		paramsSnapshot = undefined;
+		pendingParams = undefined;
 	}
 
 	function loadSavedParams(): ContentParams | undefined {

--- a/packages/ui/src/lib/components/Post.svelte
+++ b/packages/ui/src/lib/components/Post.svelte
@@ -194,10 +194,12 @@
 
 	<div
 		bind:this={container}
-		class={`flex flex-1 relative ${requiresCanvas ? 'min-h-0 overflow-hidden' : 'min-h-[80vh]'}`}
+		class={`flex flex-1 relative ${requiresCanvas ? 'min-h-0' : 'min-h-[80vh]'}`}
 	>
 		{#if requiresCanvas}
-			<canvas bind:this={cnv}>your browser does not support HTML canvas :(</canvas>
+			<canvas class="absolute inset-0 w-full h-full" bind:this={cnv}
+				>your browser does not support HTML canvas :(</canvas
+			>
 		{/if}
 
 		{#if post}

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -22,7 +22,7 @@
 	class="absolute bottom-[calc(100%+0.5rem)] right-2 w-fit min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[60vh] bg-surface rounded-md shadow-lg p-4 overflow-y-auto z-10 sm:min-w-[200px] max-sm:left-2 max-sm:min-w-0 max-sm:w-auto max-sm:p-5"
 >
 	{#each params as param}
-		<div class="flex my-2.5 max-sm:my-4">
+		<div class="flex w-full my-2.5 max-sm:my-4">
 			<ParamInput {param} onChange={onParamChange} />
 		</div>
 	{/each}

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -19,10 +19,10 @@
 </script>
 
 <div
-	class="absolute bottom-[calc(100%+0.5rem)] right-2 w-fit min-w-[200px] max-h-[60vh] bg-surface rounded-md shadow-lg p-4 overflow-y-auto z-10"
+	class="absolute bottom-[calc(100%+0.5rem)] right-2 w-fit min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[60vh] bg-surface rounded-md shadow-lg p-4 overflow-y-auto z-10 sm:min-w-[200px] max-sm:left-2 max-sm:min-w-0 max-sm:w-auto max-sm:p-5"
 >
 	{#each params as param}
-		<div class="flex my-2.5">
+		<div class="flex my-2.5 max-sm:my-4">
 			<ParamInput {param} onChange={onParamChange} />
 		</div>
 	{/each}

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -5,9 +5,11 @@
 	interface Props {
 		params: ContentParams;
 		onParamsChange: (p: ContentParams) => void;
+		onSave: () => void;
+		onCancel: () => void;
 	}
 
-	let { params = $bindable(), onParamsChange }: Props = $props();
+	let { params = $bindable(), onParamsChange, onSave, onCancel }: Props = $props();
 
 	let activeIndex = $state(0);
 	let activeParam = $derived(params[activeIndex]);
@@ -42,6 +44,10 @@
 			</button>
 		{/each}
 	</div>
+</div>
+<div class="action-bar">
+	<button class="action-btn cancel-btn" onclick={onCancel}>Cancel</button>
+	<button class="action-btn save-btn" onclick={onSave}>Save</button>
 </div>
 
 <style>
@@ -100,5 +106,43 @@
 		margin-left: 0.25rem;
 		font-variant-numeric: tabular-nums;
 		opacity: 0.6;
+	}
+
+	.action-bar {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		height: 3rem;
+		padding: 0 0.75rem;
+		background-color: var(--color-surface);
+	}
+
+	.action-btn {
+		padding: 0.375rem 1.25rem;
+		border-radius: 9999px;
+		font-size: 0.875rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.15s;
+		border: none;
+	}
+
+	.cancel-btn {
+		color: var(--color-text-secondary);
+		background: transparent;
+	}
+
+	.cancel-btn:hover {
+		color: var(--color-text);
+	}
+
+	.save-btn {
+		color: var(--color-text-strong);
+		background: var(--color-surface-active);
+		border: 1px solid var(--color-border);
+	}
+
+	.save-btn:hover {
+		background: var(--color-border);
 	}
 </style>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -9,6 +9,9 @@
 
 	let { params = $bindable(), onParamsChange }: Props = $props();
 
+	let activeIndex = $state(0);
+	let activeParam = $derived(params[activeIndex]);
+
 	function onParamChange(changedParam: ContentParam<ParamType>) {
 		if (params && onParamsChange) {
 			const newParams = params.map((p) => (p.id === changedParam.id ? changedParam : p));
@@ -18,20 +21,65 @@
 	}
 </script>
 
-<div
-	class="absolute bottom-[calc(100%+0.5rem)] right-2 w-fit min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[60vh] rounded-md shadow-lg p-4 overflow-y-auto z-10 sm:min-w-[200px] max-sm:left-2 max-sm:min-w-0 max-sm:w-auto max-sm:p-5 params-panel"
->
-	{#each params as param}
-		<div class="flex w-full my-2.5 max-sm:my-4">
-			<ParamInput {param} onChange={onParamChange} />
-		</div>
-	{/each}
+<div class="params-strip">
+	<div class="param-control">
+		<ParamInput param={activeParam} onChange={onParamChange} />
+	</div>
+	<div class="param-tabs">
+		{#each params as param, i}
+			<button class="param-tab" class:active={i === activeIndex} onclick={() => (activeIndex = i)}>
+				{param.name}
+			</button>
+		{/each}
+	</div>
 </div>
 
 <style>
-	.params-panel {
+	.params-strip {
 		background: color-mix(in srgb, var(--color-surface) 82%, transparent);
 		backdrop-filter: blur(12px);
 		-webkit-backdrop-filter: blur(12px);
+		border-top: 1px solid var(--color-border-subtle);
+	}
+
+	.param-control {
+		padding: 0.5rem 0.75rem 0;
+	}
+
+	.param-tabs {
+		display: flex;
+		overflow-x: auto;
+		gap: 0.375rem;
+		padding: 0.5rem 0.75rem;
+		-webkit-overflow-scrolling: touch;
+		scrollbar-width: none;
+	}
+
+	.param-tabs::-webkit-scrollbar {
+		display: none;
+	}
+
+	.param-tab {
+		flex-shrink: 0;
+		padding: 0.375rem 0.75rem;
+		border-radius: 9999px;
+		font-size: 0.8125rem;
+		font-weight: 500;
+		color: var(--color-text-secondary);
+		background: transparent;
+		border: 1px solid transparent;
+		cursor: pointer;
+		transition: all 0.15s;
+		white-space: nowrap;
+	}
+
+	.param-tab:hover {
+		color: var(--color-text);
+	}
+
+	.param-tab.active {
+		color: var(--color-text-heading);
+		background: var(--color-surface-active);
+		border-color: var(--color-border);
 	}
 </style>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -76,12 +76,12 @@
 		align-items: center;
 		padding: 0 0.5rem 0.5rem;
 		gap: 0.5rem;
-		overflow-y: clip;
 	}
 
 	.param-tabs {
 		display: flex;
 		overflow-x: auto;
+		overflow-y: clip;
 		gap: 0.375rem;
 		flex: 1;
 		min-width: 0;
@@ -150,7 +150,7 @@
 	}
 
 	.save-icon {
-		color: var(--color-text-strong);
+		color: var(--color-surface-secondary);
 		background: var(--color-surface-active-strong);
 	}
 

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -74,8 +74,9 @@
 	.param-row {
 		display: flex;
 		align-items: center;
-		padding: 0 0.375rem 0.5rem;
-		gap: 0.25rem;
+		padding: 0 0.5rem 0.5rem;
+		gap: 0.5rem;
+		overflow-y: clip;
 	}
 
 	.param-tabs {
@@ -130,8 +131,8 @@
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 2.25rem;
-		height: 2.25rem;
+		width: 2.5rem;
+		height: 2.5rem;
 		border-radius: 50%;
 		border: none;
 		cursor: pointer;
@@ -139,20 +140,21 @@
 	}
 
 	.cancel-icon {
-		color: var(--color-accent-danger);
-		background: color-mix(in srgb, var(--color-accent-danger) 10%, transparent);
+		color: var(--color-text-muted);
+		background: var(--color-surface-active);
 	}
 
 	.cancel-icon:hover {
-		background: color-mix(in srgb, var(--color-accent-danger) 20%, transparent);
+		color: var(--color-text-secondary);
+		background: var(--color-border);
 	}
 
 	.save-icon {
-		color: var(--color-accent-success);
-		background: color-mix(in srgb, var(--color-accent-success) 10%, transparent);
+		color: var(--color-text-strong);
+		background: var(--color-surface-active-strong);
 	}
 
 	.save-icon:hover {
-		background: color-mix(in srgb, var(--color-accent-success) 20%, transparent);
+		background: var(--color-text-heading);
 	}
 </style>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <div
-	class="absolute bottom-[calc(100%+0.5rem)] right-2 w-fit min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[60vh] bg-surface rounded-md shadow-lg p-4 overflow-y-auto z-10 sm:min-w-[200px] max-sm:left-2 max-sm:min-w-0 max-sm:w-auto max-sm:p-5"
+	class="absolute bottom-[calc(100%+0.5rem)] right-2 w-fit min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[60vh] rounded-md shadow-lg p-4 overflow-y-auto z-10 sm:min-w-[200px] max-sm:left-2 max-sm:min-w-0 max-sm:w-auto max-sm:p-5 params-panel"
 >
 	{#each params as param}
 		<div class="flex w-full my-2.5 max-sm:my-4">
@@ -27,3 +27,11 @@
 		</div>
 	{/each}
 </div>
+
+<style>
+	.params-panel {
+		background: color-mix(in srgb, var(--color-surface) 82%, transparent);
+		backdrop-filter: blur(12px);
+		-webkit-backdrop-filter: blur(12px);
+	}
+</style>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -68,7 +68,7 @@
 	}
 
 	.param-control {
-		padding: 0.5rem 0.75rem;
+		padding: 0.5rem 3.5rem;
 	}
 
 	.param-row {

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -12,6 +12,13 @@
 	let activeIndex = $state(0);
 	let activeParam = $derived(params[activeIndex]);
 
+	function formatValue(param: ContentParam<ParamType>): string {
+		if (param.type === ParamType.number && typeof param.value === 'number') {
+			return param.value % 1 === 0 ? param.value.toString() : param.value.toFixed(3);
+		}
+		return String(param.value ?? '');
+	}
+
 	function onParamChange(changedParam: ContentParam<ParamType>) {
 		if (params && onParamsChange) {
 			const newParams = params.map((p) => (p.id === changedParam.id ? changedParam : p));
@@ -29,6 +36,9 @@
 		{#each params as param, i}
 			<button class="param-tab" class:active={i === activeIndex} onclick={() => (activeIndex = i)}>
 				{param.name}
+				{#if i === activeIndex}
+					<span class="param-value">{formatValue(param)}</span>
+				{/if}
 			</button>
 		{/each}
 	</div>
@@ -43,14 +53,14 @@
 	}
 
 	.param-control {
-		padding: 0.5rem 0.75rem 0;
+		padding: 0.5rem 0.75rem;
 	}
 
 	.param-tabs {
 		display: flex;
 		overflow-x: auto;
 		gap: 0.375rem;
-		padding: 0.5rem 0.75rem;
+		padding: 0 0.75rem 0.5rem;
 		-webkit-overflow-scrolling: touch;
 		scrollbar-width: none;
 	}
@@ -69,7 +79,9 @@
 		background: transparent;
 		border: 1px solid transparent;
 		cursor: pointer;
-		transition: all 0.15s;
+		transition:
+			all 0.2s ease,
+			transform 0.2s ease;
 		white-space: nowrap;
 	}
 
@@ -81,5 +93,12 @@
 		color: var(--color-text-heading);
 		background: var(--color-surface-active);
 		border-color: var(--color-border);
+		transform: scale(1.08);
+	}
+
+	.param-value {
+		margin-left: 0.25rem;
+		font-variant-numeric: tabular-nums;
+		opacity: 0.6;
 	}
 </style>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { type ContentParam, type ContentParams, ParamType } from '$lib/content-params/index.js';
 	import ParamInput from '$lib/components/content-params/ParamInput.svelte';
+	import Icon from '$lib/components/icons/Icon.svelte';
 
 	interface Props {
 		params: ContentParams;
@@ -34,20 +35,28 @@
 	<div class="param-control">
 		<ParamInput param={activeParam} onChange={onParamChange} />
 	</div>
-	<div class="param-tabs">
-		{#each params as param, i}
-			<button class="param-tab" class:active={i === activeIndex} onclick={() => (activeIndex = i)}>
-				{param.name}
-				{#if i === activeIndex}
-					<span class="param-value">{formatValue(param)}</span>
-				{/if}
-			</button>
-		{/each}
+	<div class="param-row">
+		<button class="action-icon cancel-icon" onclick={onCancel} aria-label="Cancel changes">
+			<Icon type="circle-x" size="sm" />
+		</button>
+		<div class="param-tabs">
+			{#each params as param, i}
+				<button
+					class="param-tab"
+					class:active={i === activeIndex}
+					onclick={() => (activeIndex = i)}
+				>
+					{param.name}
+					{#if i === activeIndex}
+						<span class="param-value">{formatValue(param)}</span>
+					{/if}
+				</button>
+			{/each}
+		</div>
+		<button class="action-icon save-icon" onclick={onSave} aria-label="Save changes">
+			<Icon type="circle-check" size="sm" />
+		</button>
 	</div>
-</div>
-<div class="action-bar">
-	<button class="action-btn cancel-btn" onclick={onCancel}>Cancel</button>
-	<button class="action-btn save-btn" onclick={onSave}>Save</button>
 </div>
 
 <style>
@@ -62,11 +71,19 @@
 		padding: 0.5rem 0.75rem;
 	}
 
+	.param-row {
+		display: flex;
+		align-items: center;
+		padding: 0 0.375rem 0.5rem;
+		gap: 0.25rem;
+	}
+
 	.param-tabs {
 		display: flex;
 		overflow-x: auto;
 		gap: 0.375rem;
-		padding: 0 0.75rem 0.5rem;
+		flex: 1;
+		min-width: 0;
 		-webkit-overflow-scrolling: touch;
 		scrollbar-width: none;
 	}
@@ -108,41 +125,34 @@
 		opacity: 0.6;
 	}
 
-	.action-bar {
+	.action-icon {
+		flex-shrink: 0;
 		display: flex;
-		justify-content: space-between;
 		align-items: center;
-		height: 3rem;
-		padding: 0 0.75rem;
-		background-color: var(--color-surface);
-	}
-
-	.action-btn {
-		padding: 0.375rem 1.25rem;
-		border-radius: 9999px;
-		font-size: 0.875rem;
-		font-weight: 500;
+		justify-content: center;
+		width: 2.25rem;
+		height: 2.25rem;
+		border-radius: 50%;
+		border: none;
 		cursor: pointer;
 		transition: all 0.15s;
-		border: none;
 	}
 
-	.cancel-btn {
-		color: var(--color-text-secondary);
-		background: transparent;
+	.cancel-icon {
+		color: var(--color-accent-danger);
+		background: color-mix(in srgb, var(--color-accent-danger) 10%, transparent);
 	}
 
-	.cancel-btn:hover {
-		color: var(--color-text);
+	.cancel-icon:hover {
+		background: color-mix(in srgb, var(--color-accent-danger) 20%, transparent);
 	}
 
-	.save-btn {
-		color: var(--color-text-strong);
-		background: var(--color-surface-active);
-		border: 1px solid var(--color-border);
+	.save-icon {
+		color: var(--color-accent-success);
+		background: color-mix(in srgb, var(--color-accent-success) 10%, transparent);
 	}
 
-	.save-btn:hover {
-		background: var(--color-border);
+	.save-icon:hover {
+		background: color-mix(in srgb, var(--color-accent-success) 20%, transparent);
 	}
 </style>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -37,7 +37,7 @@
 	</div>
 	<div class="param-row">
 		<button class="action-icon cancel-icon" onclick={onCancel} aria-label="Cancel changes">
-			<Icon type="circle-x" size="sm" />
+			<Icon type="circle-x" size="sm" className="!text-inherit hover:!text-inherit" />
 		</button>
 		<div class="param-tabs">
 			{#each params as param, i}
@@ -54,7 +54,7 @@
 			{/each}
 		</div>
 		<button class="action-icon save-icon" onclick={() => onSave(params)} aria-label="Save changes">
-			<Icon type="circle-check" size="sm" />
+			<Icon type="circle-check" size="sm" className="!text-inherit hover:!text-inherit" />
 		</button>
 	</div>
 </div>

--- a/packages/ui/src/lib/components/PostParams.svelte
+++ b/packages/ui/src/lib/components/PostParams.svelte
@@ -6,7 +6,7 @@
 	interface Props {
 		params: ContentParams;
 		onParamsChange: (p: ContentParams) => void;
-		onSave: () => void;
+		onSave: (p: ContentParams) => void;
 		onCancel: () => void;
 	}
 
@@ -53,7 +53,7 @@
 				</button>
 			{/each}
 		</div>
-		<button class="action-icon save-icon" onclick={onSave} aria-label="Save changes">
+		<button class="action-icon save-icon" onclick={() => onSave(params)} aria-label="Save changes">
 			<Icon type="circle-check" size="sm" />
 		</button>
 	</div>

--- a/packages/ui/src/lib/components/content-params/ParamInput.svelte
+++ b/packages/ui/src/lib/components/content-params/ParamInput.svelte
@@ -34,10 +34,6 @@
 <div class="flex flex-col w-full">
 	{#if param.type === ParamType.number}
 		{#if numberRange}
-			<div class="flex items-center justify-between mb-1">
-				<span class="text-xs font-bold">{param.name}</span>
-				<span class="text-xs text-neutral-500 tabular-nums">{param.value}</span>
-			</div>
 			<Input
 				wrapperClass="w-full"
 				class="w-full"

--- a/packages/ui/src/lib/components/content-params/ParamInput.svelte
+++ b/packages/ui/src/lib/components/content-params/ParamInput.svelte
@@ -31,9 +31,13 @@
 	let vec2Value = $derived(param.value as unknown as Vec2);
 </script>
 
-<div class="flex flex-col w-full px-2">
+<div class="flex flex-col w-full">
 	{#if param.type === ParamType.number}
 		{#if numberRange}
+			<div class="flex items-center justify-between mb-1">
+				<span class="text-xs font-bold">{param.name}</span>
+				<span class="text-xs text-neutral-500 tabular-nums">{param.value}</span>
+			</div>
 			<Input
 				wrapperClass="w-full"
 				class="w-full"
@@ -44,10 +48,8 @@
 				onChange={onNumberParamChanged}
 				onInput={onNumberParamChanged}
 				value={param.value}
-				label={param.name}
 				name={inputId}
 			/>
-			<span class="text-xs text-neutral-500">{param.value}</span>
 		{:else}
 			<Input
 				wrapperClass="w-full"

--- a/packages/ui/src/lib/components/content-params/ParamInput.svelte
+++ b/packages/ui/src/lib/components/content-params/ParamInput.svelte
@@ -31,10 +31,11 @@
 	let vec2Value = $derived(param.value as unknown as Vec2);
 </script>
 
-<div class="flex-col px-2">
+<div class="flex flex-col w-full px-2">
 	{#if param.type === ParamType.number}
 		{#if numberRange}
 			<Input
+				wrapperClass="w-full"
 				class="w-full"
 				type="range"
 				min={numberRange.min}

--- a/packages/ui/src/lib/components/content-params/ParamInput.svelte
+++ b/packages/ui/src/lib/components/content-params/ParamInput.svelte
@@ -41,6 +41,7 @@
 				max={numberRange.max}
 				step={numberRange.step ?? 'any'}
 				onChange={onNumberParamChanged}
+				onInput={onNumberParamChanged}
 				value={param.value}
 				label={param.name}
 				name={inputId}
@@ -66,7 +67,7 @@
 			<label for={inputId} class="text-xs font-bold">{param.name}</label>
 			<select
 				id={inputId}
-				class="rounded text-md px-2 py-1"
+				class="rounded text-md px-2 py-2 min-h-[44px]"
 				value={param.value}
 				onchange={onStringSelectChanged}
 			>

--- a/packages/ui/src/lib/components/controls/Input.svelte
+++ b/packages/ui/src/lib/components/controls/Input.svelte
@@ -5,10 +5,11 @@
 		label?: string;
 		wrapperClass?: string;
 		onChange: ChangeEventHandler<HTMLInputElement>;
+		onInput?: ChangeEventHandler<HTMLInputElement>;
 		[key: string]: any;
 	}
 
-	let { label = '', wrapperClass = '', onChange, ...rest }: Props = $props();
+	let { label = '', wrapperClass = '', onChange, onInput, ...rest }: Props = $props();
 </script>
 
 <div class={`flex flex-col ${wrapperClass}`}>
@@ -17,5 +18,10 @@
 			<span class="text-xs font-bold">{label}</span>
 		{/if}
 	</label>
-	<input {...rest} class={`rounded !text-md px-2 py-1 ${rest.class}`} onchange={onChange} />
+	<input
+		{...rest}
+		class={`rounded !text-md px-2 py-1 ${rest.class}`}
+		onchange={onChange}
+		oninput={onInput}
+	/>
 </div>

--- a/packages/ui/src/lib/components/nav/Nav.svelte
+++ b/packages/ui/src/lib/components/nav/Nav.svelte
@@ -1,9 +1,11 @@
 <script>
 	import NavLink from './NavLink.svelte';
+	import { compactNav } from '$lib/state/layout';
 </script>
 
 <nav
-	class="w-full h-14 px-6 max-sm:px-3 flex flex-row content-between items-center sticky top-0 z-50 nav-bar"
+	class="w-full px-6 max-sm:px-3 flex flex-row content-between items-center sticky top-0 z-50 nav-bar"
+	class:nav-compact={$compactNav}
 >
 	<div class="flex flex-1">
 		<NavLink
@@ -23,9 +25,26 @@
 
 <style>
 	.nav-bar {
+		height: 3.5rem;
 		background: var(--nav-bg);
 		backdrop-filter: blur(var(--nav-blur));
 		-webkit-backdrop-filter: blur(var(--nav-blur));
 		border-bottom: 1px solid var(--nav-border);
+	}
+
+	@media (max-width: 639px) {
+		.nav-bar {
+			transition:
+				height 0.3s ease,
+				border-color 0.3s ease,
+				opacity 0.3s ease;
+			overflow: hidden;
+		}
+
+		.nav-bar.nav-compact {
+			height: 0;
+			border-bottom-color: transparent;
+			opacity: 0;
+		}
 	}
 </style>

--- a/packages/ui/src/lib/explorations/nyc-subway/SignalSim.svelte
+++ b/packages/ui/src/lib/explorations/nyc-subway/SignalSim.svelte
@@ -1247,11 +1247,30 @@
 
 	@media (max-width: 600px) {
 		.sim-controls {
-			padding: 10px 12px;
+			padding: 12px;
+			gap: 10px;
+		}
+		.speed-btn {
+			padding: 8px 12px;
+			font-size: 13px;
+			min-height: 36px;
+		}
+		.control-slider input[type='range'] {
+			width: 120px;
+		}
+		.toggle {
 			gap: 8px;
 		}
+		.toggle input[type='checkbox'] {
+			width: 20px;
+			height: 20px;
+		}
 		.toggle-label {
-			font-size: 11px;
+			font-size: 12px;
+		}
+		.delay-btn {
+			padding: 10px 16px;
+			font-size: 14px;
 		}
 	}
 </style>

--- a/packages/ui/src/lib/state/layout.ts
+++ b/packages/ui/src/lib/state/layout.ts
@@ -1,0 +1,3 @@
+import { writable } from 'svelte/store';
+
+export const compactNav = writable(false);


### PR DESCRIPTION
- Enlarge range slider thumbs (22px desktop, 36px on touch devices) with
  thicker tracks and vertical padding for easier tap targeting
- Add touch-action: none on range inputs to prevent scroll interference
- Wire up oninput on range sliders for real-time feedback while dragging
- Expand PostParams panel to full width on mobile with more spacing
- Increase SignalSim slider width and button touch targets on mobile
- Set min-height 44px and 16px font on number inputs/selects for touch

https://claude.ai/code/session_0138YuZ18qyMActNMAtqvyN5