### PR TITLE
Add chess opening trainer exploration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2283,6 +2283,22 @@
         "node": "*"
       }
     },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/chessground": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/chessground/-/chessground-9.2.1.tgz",
+      "integrity": "sha512-KIdxm0zD69e62XRwdnFB0XUNYSzn5HM3pMazRCwpfruRUowFI8y+1OAK5YSyBff29myeV1/4o5Q8T191+Irbog==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "GPL-3.0-or-later",
+      "funding": {
+        "url": "https://lichess.org/patron"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -7761,6 +7777,8 @@
       "dependencies": {
         "@sc/spotify": "^0.0.0",
         "@types/leaflet": "^1.9.21",
+        "chess.js": "^1.4.0",
+        "chessground": "^9.2.1",
         "date-fns": "^3.3.1",
         "grraf": "^1.0.16",
         "iconify-icon": "^2.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,6 +17,8 @@
 	"dependencies": {
 		"@sc/spotify": "^0.0.0",
 		"@types/leaflet": "^1.9.21",
+		"chess.js": "^1.4.0",
+		"chessground": "^9.2.1",
 		"date-fns": "^3.3.1",
 		"grraf": "^1.0.16",
 		"iconify-icon": "^2.0.0",

--- a/packages/ui/src/lib/entries/chess-trainer.ts
+++ b/packages/ui/src/lib/entries/chess-trainer.ts
@@ -1,0 +1,17 @@
+import { type Post, PostType } from '@sc/model';
+import ChessTrainer from '$lib/explorations/chess-trainer.svelte';
+
+const post: Post = {
+	summary: {
+		id: 'chess-trainer',
+		tags: ['chess', 'training', 'openings'],
+		title: 'Opening Trainer',
+		subtitle: 'Drill a chess opening repertoire, weighted by what opponents actually play',
+		timestamp: new Date(2026, 3, 17),
+		type: PostType.exploration,
+		isHidden: false
+	},
+	content: () => ChessTrainer
+};
+
+export default post;

--- a/packages/ui/src/lib/entries/index.ts
+++ b/packages/ui/src/lib/entries/index.ts
@@ -3,6 +3,7 @@ import antFarm from "$lib/entries/ant-farm";
 import blobConvergence from "$lib/entries/blob-convergence";
 import blobGrid from "$lib/entries/blob-grid";
 import cell from "$lib/entries/cell";
+import chessTrainer from "$lib/entries/chess-trainer";
 import chrysanthemum from "$lib/entries/chrysanthemum";
 import cubePegTorusHole from "$lib/entries/cube-peg-torus-hole";
 import downSouth from "$lib/entries/down-south";
@@ -29,6 +30,7 @@ const posts = {
     [blobConvergence.summary.id]: blobConvergence,
     [blobGrid.summary.id]: blobGrid,
     [cell.summary.id]: cell,
+    [chessTrainer.summary.id]: chessTrainer,
     [chrysanthemum.summary.id]: chrysanthemum,
     [cubePegTorusHole.summary.id]: cubePegTorusHole,
     [downSouth.summary.id]: downSouth,

--- a/packages/ui/src/lib/explorations/chess-trainer.svelte
+++ b/packages/ui/src/lib/explorations/chess-trainer.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import ChessTrainer from './chess-trainer/ChessTrainer.svelte';
+</script>
+
+<ChessTrainer />

--- a/packages/ui/src/lib/explorations/chess-trainer/Board.svelte
+++ b/packages/ui/src/lib/explorations/chess-trainer/Board.svelte
@@ -1,0 +1,99 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { Chessground } from 'chessground';
+	import type { Api } from 'chessground/api';
+	import type { Config } from 'chessground/config';
+	import type { Key, Color as CgColor, Dests } from 'chessground/types';
+	import 'chessground/assets/chessground.base.css';
+	import 'chessground/assets/chessground.brown.css';
+	import 'chessground/assets/chessground.cburnett.css';
+
+	interface Props {
+		fen: string;
+		orientation: CgColor;
+		turnColor: CgColor;
+		lastMove?: [Key, Key];
+		dests?: Dests;
+		movable?: CgColor | 'both';
+		check?: boolean;
+		viewOnly?: boolean;
+		onMove?: (from: Key, to: Key) => void;
+		onReady?: (api: Api) => void;
+	}
+
+	let {
+		fen,
+		orientation,
+		turnColor,
+		lastMove,
+		dests,
+		movable,
+		check = false,
+		viewOnly = false,
+		onMove,
+		onReady
+	}: Props = $props();
+
+	let el: HTMLDivElement | undefined = $state();
+	let api: Api | undefined;
+
+	function buildConfig(): Config {
+		return {
+			fen,
+			orientation,
+			turnColor,
+			lastMove,
+			check,
+			viewOnly,
+			coordinates: true,
+			animation: { enabled: true, duration: 180 },
+			highlight: { lastMove: true, check: true },
+			movable: {
+				color: movable,
+				dests,
+				showDests: true,
+				free: false,
+				events: {
+					after: (orig, dest) => {
+						onMove?.(orig as Key, dest as Key);
+					}
+				}
+			},
+			premovable: { enabled: false },
+			draggable: { enabled: !viewOnly, showGhost: true },
+			selectable: { enabled: !viewOnly },
+			drawable: { enabled: true, visible: true }
+		};
+	}
+
+	onMount(() => {
+		if (!el) return;
+		api = Chessground(el, buildConfig());
+		onReady?.(api);
+	});
+
+	onDestroy(() => {
+		api?.destroy();
+	});
+
+	$effect(() => {
+		if (api) api.set(buildConfig());
+	});
+</script>
+
+<div class="board-frame">
+	<div bind:this={el} class="cg-wrap"></div>
+</div>
+
+<style>
+	.board-frame {
+		width: 100%;
+		max-width: 520px;
+		margin: 0 auto;
+	}
+	.cg-wrap {
+		width: 100%;
+		aspect-ratio: 1 / 1;
+		touch-action: none;
+	}
+</style>

--- a/packages/ui/src/lib/explorations/chess-trainer/ChessTrainer.svelte
+++ b/packages/ui/src/lib/explorations/chess-trainer/ChessTrainer.svelte
@@ -1,0 +1,436 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import Board from './Board.svelte';
+	import { repertoires } from './repertoires';
+	import type { Repertoire, RepertoireMove } from './types';
+	import {
+		newTrail,
+		currentChildren,
+		turnColor,
+		isUsersTurn,
+		pickOpponentMove,
+		applyMove,
+		attemptUserMove,
+		legalDests,
+		isLineComplete
+	} from './engine';
+	import type { Trail, SquareKey } from './engine';
+	import type { Api } from 'chessground/api';
+	import type { Color as CgColor, Key, Dests } from 'chessground/types';
+
+	type Status =
+		| { kind: 'awaiting-user' }
+		| { kind: 'correct'; node: RepertoireMove }
+		| { kind: 'wrong'; attempted: string; expected: string[] }
+		| { kind: 'line-complete' };
+
+	let selected: Repertoire = $state(repertoires[0]);
+	let trail: Trail = $state(newTrail(selected));
+	let status: Status = $state({ kind: 'awaiting-user' } as Status);
+	let boardApi: Api | undefined = $state();
+	let stats = $state({ linesCompleted: 0, correctMoves: 0, mistakes: 0 });
+	let hintShown = $state(false);
+
+	// Reading trail.version subscribes derivations to chess.js mutations.
+	const fen = $derived((trail.version, trail.chess.fen()));
+	const toMove: CgColor = $derived((trail.version, turnColor(trail)) as CgColor);
+	const orientation: CgColor = $derived(selected.color as CgColor);
+	const usersTurn = $derived((trail.version, isUsersTurn(trail, selected)));
+	const children = $derived((trail.version, currentChildren(trail, selected)));
+	const dests: Dests = $derived(
+		usersTurn && status.kind !== 'line-complete'
+			? (legalDests(trail.chess) as unknown as Dests)
+			: (new Map() as Dests)
+	);
+	const movable: CgColor | undefined = $derived(usersTurn ? (toMove as CgColor) : undefined);
+	const lastMove: [Key, Key] | undefined = $derived.by(() => {
+		trail.version;
+		const history = trail.chess.history({ verbose: true });
+		if (!history.length) return undefined;
+		const last = history[history.length - 1];
+		return [last.from as Key, last.to as Key];
+	});
+
+	onMount(() => {
+		setTimeout(maybePlayOpponent, 200);
+	});
+
+	function resetLine() {
+		trail = newTrail(selected);
+		status = { kind: 'awaiting-user' };
+		hintShown = false;
+		setTimeout(maybePlayOpponent, 200);
+	}
+
+	function changeRepertoire(r: Repertoire) {
+		selected = r;
+		resetLine();
+	}
+
+	function handleRepertoireChange(e: Event) {
+		const target = e.target as HTMLSelectElement;
+		const r = repertoires.find((rep) => rep.id === target.value);
+		if (r) changeRepertoire(r);
+	}
+
+	function maybePlayOpponent() {
+		if (isLineComplete(trail, selected)) {
+			status = { kind: 'line-complete' };
+			stats.linesCompleted += 1;
+			return;
+		}
+		if (!isUsersTurn(trail, selected)) {
+			const child = pickOpponentMove(currentChildren(trail, selected));
+			applyMove(trail, child);
+			if (isLineComplete(trail, selected)) {
+				status = { kind: 'line-complete' };
+				stats.linesCompleted += 1;
+			} else {
+				status = { kind: 'awaiting-user' };
+			}
+		}
+	}
+
+	function handleUserMove(from: Key, to: Key) {
+		if (!isUsersTurn(trail, selected)) return;
+		const result = attemptUserMove(trail, selected, from as SquareKey, to as SquareKey, 'q');
+		if (!result) return;
+		if (result.kind === 'correct') {
+			stats.correctMoves += 1;
+			status = { kind: 'correct', node: result.node! };
+			hintShown = false;
+			setTimeout(() => {
+				if (isLineComplete(trail, selected)) {
+					status = { kind: 'line-complete' };
+					stats.linesCompleted += 1;
+				} else {
+					maybePlayOpponent();
+				}
+			}, 450);
+		} else {
+			stats.mistakes += 1;
+			status = {
+				kind: 'wrong',
+				attempted: result.move.san,
+				expected: children.map((c) => c.san)
+			};
+			// Revert the visual move
+			setTimeout(() => {
+				boardApi?.set({ fen: trail.chess.fen(), turnColor: toMove });
+			}, 300);
+		}
+	}
+
+	function showAnswer() {
+		if (!children.length) return;
+		hintShown = true;
+		const child = children[0];
+		const probe = trail.chess.moves({ verbose: true }).find((m) => m.san === child.san);
+		if (probe && boardApi) {
+			boardApi.setAutoShapes([
+				{
+					orig: probe.from as Key,
+					dest: probe.to as Key,
+					brush: 'green'
+				}
+			]);
+		}
+	}
+
+	function playShownMove() {
+		if (!children.length) return;
+		const child = children[0];
+		const probe = trail.chess.moves({ verbose: true }).find((m) => m.san === child.san);
+		if (!probe) return;
+		handleUserMove(probe.from as Key, probe.to as Key);
+	}
+
+	$effect(() => {
+		if (!hintShown && boardApi) {
+			boardApi.setAutoShapes([]);
+		}
+	});
+
+	const currentComment = $derived.by(() => {
+		if (status.kind === 'correct') return status.node.comment;
+		const last = trail.nodes[trail.nodes.length - 1];
+		return last?.comment;
+	});
+</script>
+
+<div class="trainer">
+	<header class="header">
+		<div class="title-row">
+			<h1>Opening Trainer</h1>
+			{#if repertoires.length > 1}
+				<select class="rep-picker" onchange={handleRepertoireChange} value={selected.id}>
+					{#each repertoires as r}
+						<option value={r.id}>{r.name}</option>
+					{/each}
+				</select>
+			{/if}
+		</div>
+		<p class="description">{selected.description ?? ''}</p>
+		<div class="side-tag">
+			You play <strong>{selected.color}</strong>
+		</div>
+	</header>
+
+	<div class="board-container">
+		<Board
+			{fen}
+			{orientation}
+			turnColor={toMove}
+			{lastMove}
+			{dests}
+			{movable}
+			onMove={handleUserMove}
+			onReady={(api) => (boardApi = api)}
+		/>
+	</div>
+
+	<div
+		class="status"
+		class:status-correct={status.kind === 'correct'}
+		class:status-wrong={status.kind === 'wrong'}
+		class:status-complete={status.kind === 'line-complete'}
+	>
+		{#if status.kind === 'awaiting-user'}
+			<div class="prompt">
+				{#if usersTurn}
+					Your move. <span class="muted">({toMove} to play)</span>
+				{:else}
+					<span class="muted">Thinking…</span>
+				{/if}
+			</div>
+			{#if currentComment}
+				<div class="comment">{currentComment}</div>
+			{/if}
+		{:else if status.kind === 'correct'}
+			<div class="prompt">Good move: <strong>{status.node.san}</strong></div>
+			{#if status.node.comment}
+				<div class="comment">{status.node.comment}</div>
+			{/if}
+		{:else if status.kind === 'wrong'}
+			<div class="prompt">
+				Not in book: <strong>{status.attempted}</strong>.
+				<span class="muted">Try again.</span>
+			</div>
+			<div class="comment">
+				Expected: {status.expected.join(' or ')}
+			</div>
+		{:else if status.kind === 'line-complete'}
+			<div class="prompt">Line complete — nice work.</div>
+			<button class="primary" onclick={resetLine}>Next line</button>
+		{/if}
+	</div>
+
+	<div class="controls">
+		<button onclick={resetLine} class="secondary">Reset line</button>
+		{#if status.kind !== 'line-complete' && usersTurn}
+			{#if !hintShown}
+				<button onclick={showAnswer} class="secondary">Show answer</button>
+			{:else}
+				<button onclick={playShownMove} class="secondary">Play it</button>
+			{/if}
+		{/if}
+	</div>
+
+	<div class="stats">
+		<div class="stat">
+			<span class="stat-value">{stats.linesCompleted}</span>
+			<span class="stat-label">lines</span>
+		</div>
+		<div class="stat">
+			<span class="stat-value">{stats.correctMoves}</span>
+			<span class="stat-label">correct</span>
+		</div>
+		<div class="stat">
+			<span class="stat-value">{stats.mistakes}</span>
+			<span class="stat-label">mistakes</span>
+		</div>
+	</div>
+</div>
+
+<style>
+	.trainer {
+		max-width: 640px;
+		margin: 0 auto;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 16px;
+		color: #1a1a1a;
+	}
+
+	.header {
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.title-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 12px;
+		flex-wrap: wrap;
+	}
+
+	.header h1 {
+		font-size: 1.5rem;
+		font-weight: 700;
+		margin: 0;
+		letter-spacing: -0.01em;
+	}
+
+	.rep-picker {
+		padding: 6px 10px;
+		border-radius: 6px;
+		border: 1px solid rgba(0, 0, 0, 0.15);
+		background: white;
+		font-size: 14px;
+	}
+
+	.description {
+		font-size: 13px;
+		color: rgba(0, 0, 0, 0.55);
+		margin: 0;
+		line-height: 1.5;
+	}
+
+	.side-tag {
+		font-size: 12px;
+		color: rgba(0, 0, 0, 0.5);
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+	}
+
+	.side-tag strong {
+		color: #1a1a1a;
+		text-transform: capitalize;
+	}
+
+	.board-container {
+		display: flex;
+		justify-content: center;
+	}
+
+	.status {
+		background: rgba(0, 0, 0, 0.03);
+		border-radius: 10px;
+		padding: 14px 16px;
+		border-left: 3px solid rgba(0, 0, 0, 0.15);
+		min-height: 64px;
+		display: flex;
+		flex-direction: column;
+		gap: 6px;
+	}
+
+	.status-correct {
+		border-left-color: #00a854;
+		background: rgba(0, 168, 84, 0.06);
+	}
+
+	.status-wrong {
+		border-left-color: #d63031;
+		background: rgba(214, 48, 49, 0.06);
+	}
+
+	.status-complete {
+		border-left-color: #1677ff;
+		background: rgba(22, 119, 255, 0.06);
+	}
+
+	.prompt {
+		font-size: 15px;
+		font-weight: 500;
+	}
+
+	.comment {
+		font-size: 13px;
+		color: rgba(0, 0, 0, 0.6);
+		line-height: 1.5;
+	}
+
+	.muted {
+		color: rgba(0, 0, 0, 0.45);
+		font-weight: 400;
+	}
+
+	.controls {
+		display: flex;
+		gap: 8px;
+		flex-wrap: wrap;
+	}
+
+	button {
+		font: inherit;
+		padding: 10px 16px;
+		border-radius: 8px;
+		cursor: pointer;
+		font-weight: 500;
+		font-size: 14px;
+		border: 1px solid transparent;
+		transition: background 0.15s;
+	}
+
+	button.primary {
+		background: #1677ff;
+		color: white;
+		border-color: #1677ff;
+	}
+	button.primary:hover {
+		background: #0a60d8;
+	}
+
+	button.secondary {
+		background: white;
+		border-color: rgba(0, 0, 0, 0.15);
+		color: #1a1a1a;
+	}
+	button.secondary:hover {
+		background: rgba(0, 0, 0, 0.04);
+	}
+
+	.stats {
+		display: flex;
+		gap: 16px;
+		padding-top: 8px;
+		border-top: 1px solid rgba(0, 0, 0, 0.06);
+	}
+
+	.stat {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.stat-value {
+		font-size: 20px;
+		font-weight: 700;
+		color: #1a1a1a;
+	}
+
+	.stat-label {
+		font-size: 11px;
+		color: rgba(0, 0, 0, 0.45);
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+	}
+
+	@media (max-width: 480px) {
+		.trainer {
+			padding: 12px;
+		}
+		.header h1 {
+			font-size: 1.25rem;
+		}
+		.controls {
+			flex-direction: row;
+		}
+		.controls button {
+			flex: 1;
+		}
+	}
+</style>

--- a/packages/ui/src/lib/explorations/chess-trainer/ChessTrainer.svelte
+++ b/packages/ui/src/lib/explorations/chess-trainer/ChessTrainer.svelte
@@ -30,6 +30,8 @@
 	let boardApi: Api | undefined = $state();
 	let stats = $state({ linesCompleted: 0, correctMoves: 0, mistakes: 0 });
 	let hintShown = $state(false);
+	let whyShown = $state(false);
+	let aboutOpen = $state(false);
 
 	// Reading trail.version subscribes derivations to chess.js mutations.
 	const fen = $derived((trail.version, trail.chess.fen()));
@@ -59,6 +61,7 @@
 		trail = newTrail(selected);
 		status = { kind: 'awaiting-user' };
 		hintShown = false;
+		whyShown = false;
 		setTimeout(maybePlayOpponent, 200);
 	}
 
@@ -99,6 +102,7 @@
 			stats.correctMoves += 1;
 			status = { kind: 'correct', node: result.node! };
 			hintShown = false;
+			whyShown = false;
 			setTimeout(() => {
 				if (isLineComplete(trail, selected)) {
 					status = { kind: 'line-complete' };
@@ -156,6 +160,11 @@
 		const last = trail.nodes[trail.nodes.length - 1];
 		return last?.comment;
 	});
+
+	const upcomingComment = $derived(children[0]?.comment);
+	const hasAbout = $derived(
+		Boolean(selected.historicalContext || selected.strategicConcepts?.length)
+	);
 </script>
 
 <div class="trainer">
@@ -172,9 +181,29 @@
 		</div>
 		<p class="description">{selected.description ?? ''}</p>
 		<div class="side-tag">
+			{#if selected.ecoCode}<span class="eco">{selected.ecoCode}</span>{/if}
 			You play <strong>{selected.color}</strong>
 		</div>
 	</header>
+
+	{#if hasAbout}
+		<details class="about" bind:open={aboutOpen}>
+			<summary>About this opening</summary>
+			{#if selected.historicalContext}
+				<p class="about-history">{selected.historicalContext}</p>
+			{/if}
+			{#if selected.strategicConcepts?.length}
+				<ul class="concepts">
+					{#each selected.strategicConcepts as c}
+						<li>
+							<span class="concept-name">{c.concept}</span>
+							<span class="concept-explain">{c.explanation}</span>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</details>
+	{/if}
 
 	<div class="board-container">
 		<Board
@@ -206,10 +235,26 @@
 			{#if currentComment}
 				<div class="comment">{currentComment}</div>
 			{/if}
+			{#if whyShown && upcomingComment}
+				<div class="why-hint">
+					<span class="why-label">Why:</span>
+					{upcomingComment}
+				</div>
+			{/if}
 		{:else if status.kind === 'correct'}
 			<div class="prompt">Good move: <strong>{status.node.san}</strong></div>
 			{#if status.node.comment}
 				<div class="comment">{status.node.comment}</div>
+			{/if}
+			{#if status.node.sourceQuote || status.node.source}
+				<blockquote class="source-quote">
+					{#if status.node.sourceQuote}
+						<p>“{status.node.sourceQuote}”</p>
+					{/if}
+					{#if status.node.source}
+						<cite>— {status.node.source}</cite>
+					{/if}
+				</blockquote>
 			{/if}
 		{:else if status.kind === 'wrong'}
 			<div class="prompt">
@@ -228,6 +273,9 @@
 	<div class="controls">
 		<button onclick={resetLine} class="secondary">Reset line</button>
 		{#if status.kind !== 'line-complete' && usersTurn}
+			{#if upcomingComment && !whyShown}
+				<button onclick={() => (whyShown = true)} class="secondary">Why?</button>
+			{/if}
 			{#if !hintShown}
 				<button onclick={showAnswer} class="secondary">Show answer</button>
 			{:else}
@@ -311,6 +359,68 @@
 		text-transform: capitalize;
 	}
 
+	.eco {
+		display: inline-block;
+		padding: 1px 6px;
+		margin-right: 8px;
+		border-radius: 3px;
+		background: rgba(0, 0, 0, 0.08);
+		color: #1a1a1a;
+		font-weight: 600;
+		letter-spacing: 0.04em;
+	}
+
+	.about {
+		background: rgba(0, 0, 0, 0.03);
+		border-radius: 10px;
+		padding: 8px 14px;
+		font-size: 14px;
+	}
+	.about[open] {
+		padding-bottom: 14px;
+	}
+	.about summary {
+		cursor: pointer;
+		padding: 6px 0;
+		font-weight: 600;
+		color: #1a1a1a;
+		font-size: 14px;
+		user-select: none;
+	}
+	.about summary:hover {
+		color: #1677ff;
+	}
+	.about-history {
+		margin: 6px 0 12px;
+		line-height: 1.6;
+		color: rgba(0, 0, 0, 0.7);
+	}
+	.concepts {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+	.concepts li {
+		padding-left: 10px;
+		border-left: 2px solid rgba(0, 0, 0, 0.12);
+	}
+	.concept-name {
+		display: block;
+		font-weight: 600;
+		color: #1a1a1a;
+		font-size: 13px;
+		margin-bottom: 2px;
+	}
+	.concept-explain {
+		display: block;
+		color: rgba(0, 0, 0, 0.6);
+		font-size: 13px;
+		line-height: 1.5;
+	}
+
 	.board-container {
 		display: flex;
 		justify-content: center;
@@ -351,6 +461,41 @@
 		font-size: 13px;
 		color: rgba(0, 0, 0, 0.6);
 		line-height: 1.5;
+	}
+
+	.why-hint {
+		font-size: 13px;
+		color: rgba(0, 0, 0, 0.7);
+		line-height: 1.5;
+		padding: 8px 10px;
+		background: rgba(255, 204, 10, 0.12);
+		border-left: 2px solid #fccc0a;
+		border-radius: 4px;
+	}
+	.why-label {
+		font-weight: 600;
+		margin-right: 4px;
+		color: #8a6d00;
+	}
+
+	.source-quote {
+		margin: 4px 0 0;
+		padding: 8px 12px;
+		border-left: 3px solid rgba(0, 0, 0, 0.2);
+		background: rgba(0, 0, 0, 0.02);
+		border-radius: 0 4px 4px 0;
+	}
+	.source-quote p {
+		margin: 0 0 4px;
+		font-size: 13px;
+		font-style: italic;
+		color: rgba(0, 0, 0, 0.7);
+		line-height: 1.5;
+	}
+	.source-quote cite {
+		font-size: 11px;
+		color: rgba(0, 0, 0, 0.5);
+		font-style: normal;
 	}
 
 	.muted {

--- a/packages/ui/src/lib/explorations/chess-trainer/engine.ts
+++ b/packages/ui/src/lib/explorations/chess-trainer/engine.ts
@@ -1,0 +1,103 @@
+import { Chess, type Move as ChessMove, type Square } from 'chess.js';
+import type { Color, Repertoire, RepertoireMove } from './types';
+
+export interface Trail {
+	chess: Chess;
+	nodes: RepertoireMove[];
+	version: number;
+}
+
+export function newTrail(repertoire: Repertoire): Trail {
+	return {
+		chess: new Chess(repertoire.startFen),
+		nodes: [],
+		version: 0
+	};
+}
+
+export function currentChildren(trail: Trail, repertoire: Repertoire): RepertoireMove[] {
+	const last = trail.nodes[trail.nodes.length - 1];
+	return last?.children ?? repertoire.root;
+}
+
+export function turnColor(trail: Trail): Color {
+	return trail.chess.turn() === 'w' ? 'white' : 'black';
+}
+
+export function isUsersTurn(trail: Trail, repertoire: Repertoire): boolean {
+	return turnColor(trail) === repertoire.color;
+}
+
+function pickWeighted(moves: RepertoireMove[]): RepertoireMove {
+	const total = moves.reduce((s, m) => s + (m.weight ?? 1), 0);
+	let r = Math.random() * total;
+	for (const m of moves) {
+		r -= m.weight ?? 1;
+		if (r <= 0) return m;
+	}
+	return moves[moves.length - 1];
+}
+
+export function pickOpponentMove(children: RepertoireMove[]): RepertoireMove {
+	return pickWeighted(children);
+}
+
+export function applyMove(trail: Trail, node: RepertoireMove): ChessMove | null {
+	const move = trail.chess.move(node.san);
+	if (!move) return null;
+	trail.nodes.push(node);
+	trail.version += 1;
+	return move;
+}
+
+export function findUserMove(
+	children: RepertoireMove[],
+	sanOrVerbose: { san: string } | string
+): RepertoireMove | undefined {
+	const san = typeof sanOrVerbose === 'string' ? sanOrVerbose : sanOrVerbose.san;
+	return children.find((c) => c.san === san);
+}
+
+export type SquareKey = Square;
+
+export function legalDests(chess: Chess): Map<SquareKey, SquareKey[]> {
+	const dests = new Map<SquareKey, SquareKey[]>();
+	for (const move of chess.moves({ verbose: true })) {
+		const list = dests.get(move.from) ?? [];
+		list.push(move.to);
+		dests.set(move.from, list);
+	}
+	return dests;
+}
+
+export interface AttemptResult {
+	kind: 'correct' | 'incorrect';
+	move: ChessMove;
+	node?: RepertoireMove;
+}
+
+export function attemptUserMove(
+	trail: Trail,
+	repertoire: Repertoire,
+	from: SquareKey,
+	to: SquareKey,
+	promotion?: 'q' | 'r' | 'b' | 'n'
+): AttemptResult | null {
+	const probe = new Chess(trail.chess.fen());
+	const attempt = probe.move({ from, to, promotion: promotion ?? 'q' });
+	if (!attempt) return null;
+
+	const children = currentChildren(trail, repertoire);
+	const matched = children.find((c) => c.san === attempt.san);
+	if (matched) {
+		const real = trail.chess.move({ from, to, promotion: promotion ?? 'q' })!;
+		trail.nodes.push(matched);
+		trail.version += 1;
+		return { kind: 'correct', move: real, node: matched };
+	}
+	return { kind: 'incorrect', move: attempt };
+}
+
+export function isLineComplete(trail: Trail, repertoire: Repertoire): boolean {
+	return currentChildren(trail, repertoire).length === 0;
+}

--- a/packages/ui/src/lib/explorations/chess-trainer/repertoires/index.ts
+++ b/packages/ui/src/lib/explorations/chess-trainer/repertoires/index.ts
@@ -1,0 +1,4 @@
+import type { Repertoire } from '../types';
+import ponziani from './ponziani';
+
+export const repertoires: Repertoire[] = [ponziani];

--- a/packages/ui/src/lib/explorations/chess-trainer/repertoires/ponziani.ts
+++ b/packages/ui/src/lib/explorations/chess-trainer/repertoires/ponziani.ts
@@ -3,9 +3,35 @@ import type { Repertoire } from '../types';
 const ponziani: Repertoire = {
 	id: 'ponziani',
 	name: 'Ponziani Opening',
+	aliases: ['Staunton Opening', 'English Attack (historical)'],
+	ecoCode: 'C44',
 	color: 'white',
 	description:
 		'White plays 3.c3 after 1.e4 e5 2.Nf3 Nc6, preparing d4 to seize the centre. A starter tree — edit to match your own lines.',
+	historicalContext:
+		'Named after Domenico Lorenzo Ponziani, an 18th-century Italian master whose 1769 treatise analysed the opening in depth. The move 3.c3 belongs to the old Italian school: rather than develop a piece, White spends a tempo to prepare an uncontested d2–d4 push. The opening faded from top-level play in the 20th century as defences for Black were refined, but remains a practical surprise weapon at club level.',
+	strategicConcepts: [
+		{
+			concept: 'Pay tempo for the centre',
+			explanation:
+				"3.c3 is a non-developing move, so White is consciously 'buying' central control with time. The trade is only worth it if White follows up with an energetic d4. If the d4 push never comes, the move is simply slow."
+		},
+		{
+			concept: 'Sidestep ...Bb4',
+			explanation:
+				'Unlike Italian Game lines with 3.Bc4 where Black can pin with ...Bb4+ or disrupt with ...Nd4, 3.c3 denies the b4-square to the dark-squared bishop. This small detail is why c3 is played before the bishop comes out.'
+		},
+		{
+			concept: 'Kick the knight with d5',
+			explanation:
+				"When Black responds with 3...Nf6 4.d4 Nxe4, White's plan is the tempo-gaining 5.d5, driving the c6-knight to a passive square while preparing to recover the e4-pawn. The whole line hinges on this intermezzo."
+		},
+		{
+			concept: 'Respect the Jaenisch (3...d5)',
+			explanation:
+				'Black can break centrally with 3...d5, attacking e4 and discouraging d4. The principled response is 4.Qa4 — the queen both pins the c6-knight and presses d5, exploiting the fact that Black has not yet developed.'
+		}
+	],
 	root: [
 		{
 			san: 'e4',

--- a/packages/ui/src/lib/explorations/chess-trainer/repertoires/ponziani.ts
+++ b/packages/ui/src/lib/explorations/chess-trainer/repertoires/ponziani.ts
@@ -1,0 +1,216 @@
+import type { Repertoire } from '../types';
+
+const ponziani: Repertoire = {
+	id: 'ponziani',
+	name: 'Ponziani Opening',
+	color: 'white',
+	description:
+		'White plays 3.c3 after 1.e4 e5 2.Nf3 Nc6, preparing d4 to seize the centre. A starter tree — edit to match your own lines.',
+	root: [
+		{
+			san: 'e4',
+			comment: 'Claim the centre.',
+			children: [
+				{
+					san: 'e5',
+					weight: 6,
+					children: [
+						{
+							san: 'Nf3',
+							comment: 'Develop and attack e5.',
+							children: [
+								{
+									san: 'Nc6',
+									weight: 6,
+									children: [
+										{
+											san: 'c3',
+											comment: 'The Ponziani — prepare d4 without allowing ...Bb4.',
+											children: [
+												{
+													san: 'Nf6',
+													weight: 4,
+													comment: 'Most common — Black attacks e4.',
+													children: [
+														{
+															san: 'd4',
+															comment: 'Push through. If Nxe4, we kick with d5 gaining tempo.',
+															children: [
+																{
+																	san: 'Nxe4',
+																	weight: 3,
+																	children: [
+																		{
+																			san: 'd5',
+																			comment: 'Kick the knight from c6 with tempo.',
+																			children: [
+																				{
+																					san: 'Ne7',
+																					weight: 3,
+																					children: [
+																						{
+																							san: 'Nxe5',
+																							comment: 'Win the pawn back.'
+																						}
+																					]
+																				},
+																				{
+																					san: 'Nb8',
+																					weight: 2,
+																					children: [
+																						{
+																							san: 'Bd3',
+																							comment: 'Develop, attack the Ne4.'
+																						}
+																					]
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	san: 'exd4',
+																	weight: 2,
+																	children: [
+																		{
+																			san: 'e5',
+																			comment: 'Push and gain space — the Nf6 must move.',
+																			children: [
+																				{
+																					san: 'Nd5',
+																					weight: 2,
+																					children: [
+																						{
+																							san: 'Qxd4',
+																							comment: 'Recapture, centralise the queen.'
+																						}
+																					]
+																				},
+																				{
+																					san: 'Ne4',
+																					weight: 1,
+																					children: [
+																						{
+																							san: 'Qxd4',
+																							comment: 'Recapture, threaten Qxe4.'
+																						}
+																					]
+																				}
+																			]
+																		}
+																	]
+																},
+																{
+																	san: 'd6',
+																	weight: 1,
+																	children: [
+																		{
+																			san: 'dxe5',
+																			comment: 'Open lines, Black must recapture awkwardly.'
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													san: 'd5',
+													weight: 3,
+													comment: 'The Jaenisch — sharp counterattack.',
+													children: [
+														{
+															san: 'Qa4',
+															comment: 'Pin the knight and add pressure on d5.',
+															children: [
+																{
+																	san: 'Nf6',
+																	weight: 2,
+																	children: [{ san: 'Nxe5', comment: 'Grab the pawn.' }]
+																},
+																{
+																	san: 'dxe4',
+																	weight: 2,
+																	children: [
+																		{ san: 'Nxe5', comment: 'Double attack — Qa4 hits c6.' }
+																	]
+																},
+																{
+																	san: 'f6',
+																	weight: 1,
+																	children: [
+																		{ san: 'Bb5', comment: 'Pin — Black is already struggling.' }
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													san: 'd6',
+													weight: 2,
+													comment: 'Passive — we get a free hand in the centre.',
+													children: [
+														{
+															san: 'd4',
+															children: [
+																{
+																	san: 'Nf6',
+																	weight: 2,
+																	children: [{ san: 'Bd3', comment: 'Simple development.' }]
+																},
+																{
+																	san: 'Bg4',
+																	weight: 1,
+																	children: [
+																		{
+																			san: 'dxe5',
+																			comment: 'Open the position before he develops.'
+																		}
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													san: 'f5',
+													weight: 1,
+													comment: 'Aggressive but weakening.',
+													children: [
+														{
+															san: 'd4',
+															comment:
+																"Don't take on f5 — keep the centre and punish the weakness later.",
+															children: [
+																{
+																	san: 'fxe4',
+																	weight: 2,
+																	children: [
+																		{ san: 'Nxe5', comment: 'Equal material, better structure.' }
+																	]
+																}
+															]
+														}
+													]
+												},
+												{
+													san: 'Be7',
+													weight: 1,
+													comment: 'Passive — play for a classical centre.',
+													children: [{ san: 'd4', comment: 'Build the ideal centre.' }]
+												}
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+};
+
+export default ponziani;

--- a/packages/ui/src/lib/explorations/chess-trainer/types.ts
+++ b/packages/ui/src/lib/explorations/chess-trainer/types.ts
@@ -1,8 +1,15 @@
 export type Color = 'white' | 'black';
 
+export interface StrategicConcept {
+	concept: string;
+	explanation: string;
+}
+
 export interface RepertoireMove {
 	san: string;
 	comment?: string;
+	source?: string;
+	sourceQuote?: string;
 	weight?: number;
 	children?: RepertoireMove[];
 }
@@ -10,8 +17,12 @@ export interface RepertoireMove {
 export interface Repertoire {
 	id: string;
 	name: string;
+	aliases?: string[];
+	ecoCode?: string;
 	color: Color;
 	description?: string;
+	historicalContext?: string;
+	strategicConcepts?: StrategicConcept[];
 	startFen?: string;
 	root: RepertoireMove[];
 }

--- a/packages/ui/src/lib/explorations/chess-trainer/types.ts
+++ b/packages/ui/src/lib/explorations/chess-trainer/types.ts
@@ -1,0 +1,17 @@
+export type Color = 'white' | 'black';
+
+export interface RepertoireMove {
+	san: string;
+	comment?: string;
+	weight?: number;
+	children?: RepertoireMove[];
+}
+
+export interface Repertoire {
+	id: string;
+	name: string;
+	color: Color;
+	description?: string;
+	startFen?: string;
+	root: RepertoireMove[];
+}


### PR DESCRIPTION
Drills a hand-authored repertoire tree with chess.js + chessground.
Opponent moves are picked weighted so you see popular responses,
not just the main line. Wrong moves flash red and revert; correct
moves advance automatically. Starter Ponziani repertoire included.

https://claude.ai/code/session_01DpqcKsSzi3PcHJ4ZuDNYaQ